### PR TITLE
Use regular class methods instead of static class properties

### DIFF
--- a/lib/SerializablePath.js
+++ b/lib/SerializablePath.js
@@ -15,7 +15,7 @@ export default class SerializablePath {
     }
 
     /* parser */
-    push = () => {
+    push() {
         let p = Array.prototype.join.call(arguments, ' ')
             .replace(/(\.\d+)(?=\-?\.)/ig, '$1,') //-.3-.575 => -.3,-.575
             .match(/[a-df-z]|[\-+]?(?:[\d\.]e[\-+]?|[^\s\-+,a-z])+/ig);
@@ -67,41 +67,41 @@ export default class SerializablePath {
             cmd = p[i++];
         }
         return this;
-    };
+    }
 
     /* utility methods */
 
-    reset = () => {
+    reset() {
         this.penX = this.penY = 0;
         this.penDownX = this.penDownY = null;
         this._pivotX = this._pivotY = 0;
         this.onReset();
         return this;
-    };
+    }
 
-    move = (x,y) => {
+    move(x,y) {
         this.onMove(this.penX, this.penY, this._pivotX = this.penX += (+x), this._pivotY = this.penY += (+y));
         return this;
-    };
+    }
 
-    moveTo = (x,y) => {
+    moveTo(x,y) {
         this.onMove(this.penX, this.penY, this._pivotX = this.penX = (+x), this._pivotY = this.penY = (+y));
         return this;
-    };
+    }
 
-    line = (x,y) => {
+    line(x,y) {
         return this.lineTo(this.penX + (+x), this.penY + (+y));
-    };
+    }
 
-    lineTo = (x,y) => {
+    lineTo(x,y) {
         if (_.isNil(this.penDownX)) {
             this.penDownX = this.penX; this.penDownY = this.penY;
         }
         this.onLine(this.penX, this.penY, this._pivotX = this.penX = (+x), this._pivotY = this.penY = (+y));
         return this;
-    };
+    }
 
-    curve = (c1x, c1y, c2x, c2y, ex, ey) => {
+    curve(c1x, c1y, c2x, c2y, ex, ey) {
         let x = this.penX,
             y = this.penY;
 
@@ -112,9 +112,9 @@ export default class SerializablePath {
             _.isNil(ex) ? null : x + (+ex),
             _.isNil(ey) ? null : y + (+ey)
         );
-    };
+    }
 
-    curveTo = (c1x, c1y, c2x, c2y, ex, ey) => {
+    curveTo(c1x, c1y, c2x, c2y, ex, ey) {
         let x = this.penX,
             y = this.penY;
 
@@ -136,13 +136,13 @@ export default class SerializablePath {
         }
         this.onBezierCurve(x, y, +c1x, +c1y, +c2x, +c2y, this.penX = +ex, this.penY = +ey);
         return this;
-    };
+    }
 
-    arc = (x, y, rx, ry, outer, counterClockwise, rotation) => {
+    arc(x, y, rx, ry, outer, counterClockwise, rotation) {
         return this.arcTo(this.penX + (+x), this.penY + (+y), rx, ry, outer, counterClockwise, rotation);
-    };
+    }
 
-    arcTo = (x, y, rx, ry, outer, counterClockwise, rotation) => {
+    arcTo(x, y, rx, ry, outer, counterClockwise, rotation) {
         ry = Math.abs(+ry || +rx || (+y - this.penY));
         rx = Math.abs(+rx || (+x - this.penX));
 
@@ -199,43 +199,43 @@ export default class SerializablePath {
             cx, cy, rx, ry, sa, ea, !clockwise, rotation
         );
         return this;
-    };
+    }
 
-    counterArc = (x, y, rx, ry, outer) =>{
+    counterArc(x, y, rx, ry, outer) {
         return this.arc(x, y, rx, ry, outer, true);
-    };
+    }
 
-    counterArcTo = (x, y, rx, ry, outer) => {
+    counterArcTo(x, y, rx, ry, outer) {
         return this.arcTo(x, y, rx, ry, outer, true);
-    };
+    }
 
-    close = () => {
+    close() {
         if (!_.isNil(this.penDownX)){
             this.onClose(this.penX, this.penY, this.penX = this.penDownX, this.penY = this.penDownY);
             this.penDownX = null;
         }
         return this;
-    };
+    }
 
     /* overridable handlers */
 
-    onReset = () => {
+    onReset() {
         this.path = [];
-    };
+    }
 
-    onMove = (sx, sy, x, y) => {
+    onMove(sx, sy, x, y) {
         this.path.push(MOVE_TO, x, y);
-    };
+    }
 
-    onLine = (sx, sy, x, y) => {
+    onLine(sx, sy, x, y) {
         this.path.push(LINE_TO, x, y);
-    };
+    }
 
-    onBezierCurve = (sx, sy, p1x, p1y, p2x, p2y, x, y) => {
+    onBezierCurve(sx, sy, p1x, p1y, p2x, p2y, x, y) {
         this.path.push(CURVE_TO, p1x, p1y, p2x, p2y, x, y);
-    };
+    }
 
-    _arcToBezier = (sx, sy, ex, ey, cx, cy, rx, ry, sa, ea, ccw, rotation) => {
+    _arcToBezier(sx, sy, ex, ey, cx, cy, rx, ry, sa, ea, ccw, rotation) {
         // Inverse Rotation + Scale Transform
         let rad = rotation ? rotation * Math.PI / 180 : 0,
             cos = Math.cos(rad), sin = Math.sin(rad),
@@ -271,19 +271,19 @@ export default class SerializablePath {
                 (sx = (cx + xx * x + yx * y)), (sy = (cy + xy * x + yy * y))
             );
         }
-    };
+    }
 
-    onArc = (sx, sy, ex, ey, cx, cy, rx, ry, sa, ea, ccw, rotation) => {
+    onArc(sx, sy, ex, ey, cx, cy, rx, ry, sa, ea, ccw, rotation) {
         return this._arcToBezier(
             sx, sy, ex, ey, cx, cy, rx, ry, sa, ea, ccw, rotation
         );
-    };
+    }
 
-    onClose = () => {
+    onClose() {
         this.path.push(CLOSE);
-    };
+    }
 
-    toJSON = () => {
+    toJSON() {
         return this.path;
-    };
+    }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "devDependencies": {
         "babel-eslint": "^6.1.2",
         "eslint": "^2.13.1",
-        "eslint-plugin-react": "^4.3.0"
+        "eslint-plugin-react": "^4.3.0",
+        "react-native": ">=0.33.0"
     },
     "nativePackage": true
 }


### PR DESCRIPTION
This fixes a `this` binding issue causing _this.onReset in SerializablePath to throw 'undefined is not a function'. This happens when not using React Native's default Babel config, which is a requirement for some projects [such as Relay](https://facebook.github.io/relay/docs/guides-babel-plugin.html).
