### PR TITLE
Changed the Path PropTypes to accept SerializablePaths directly

### DIFF
--- a/elements/Path.js
+++ b/elements/Path.js
@@ -13,7 +13,7 @@ class Path extends Shape {
         d: React.PropTypes.oneOfType([
             React.PropTypes.string,
             React.PropTypes.instanceOf(SerializablePath)
-        ])
+        ]).isRequired
     };
 
     setNativeProps = (...args) => {

--- a/elements/Path.js
+++ b/elements/Path.js
@@ -10,7 +10,10 @@ class Path extends Shape {
 
     static propTypes = {
         ...pathProps,
-        d: PropTypes.string.isRequired
+        d: React.PropTypes.oneOfType([
+            React.PropTypes.string,
+            React.PropTypes.instanceOf(SerializablePath)
+        ])
     };
 
     setNativeProps = (...args) => {


### PR DESCRIPTION
If you want to programmatically build paths for example
