### PR TITLE
Better font family check on iOS to support custom fonts

### DIFF
--- a/ios/Utils/RCTConvert+RNSVG.m
+++ b/ios/Utils/RCTConvert+RNSVG.m
@@ -102,9 +102,22 @@ RCT_ENUM_CONVERTER(RNSVGVBMOS, (@{
     NSDictionary *fontDict = dict[@"font"];
     NSString *fontFamily = fontDict[@"fontFamily"];
     
-    if (![[UIFont familyNames] containsObject:fontFamily]) {
-        fontFamily = nil;
+    BOOL fontFound = NO;
+    NSArray *supportedFontFamilyNames = [UIFont familyNames];
+
+    if ([supportedFontFamilyNames containsObject:fontFamily]) {
+      fontFound = YES;
+    } else {
+      for (NSString *fontFamilyName in supportedFontFamilyNames) {
+        if ([[UIFont fontNamesForFamilyName: fontFamilyName] containsObject:fontFamily]) {
+          fontFound = YES;
+          break;
+        }
+      }
     }
+
+    fontFamily = fontFound ? fontFamily : nil;
+
 
     CTFontRef font = (__bridge CTFontRef)[RCTFont updateFont:nil withFamily:fontFamily size:fontDict[@"fontSize"] weight:fontDict[@"fontWeight"] style:fontDict[@"fontStyle"]
                                                       variant:nil scaleMultiplier:1.0];


### PR DESCRIPTION
Font names can be specified as something like `Helvetica-Bold`. This is specially common when using custom fonts. This fix makes sure those supported custom fonts are not accidentally removed.

Fix #122