### PR TITLE
Mark all descendants of Defs as seen after a draw

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RNSVGDefsShadowNode.java
+++ b/android/src/main/java/com/horcrux/svg/RNSVGDefsShadowNode.java
@@ -28,7 +28,7 @@ public class RNSVGDefsShadowNode extends RNSVGDefinitionShadowNode {
         traverseChildren(new NodeRunnable() {
             public boolean run(RNSVGVirtualNode node) {
                 node.markUpdateSeen();
-                node.traverseChildren(this);
+                node.traverseChildren(NodeRunnable.this);
                 return true;
             }
         });

--- a/android/src/main/java/com/horcrux/svg/RNSVGDefsShadowNode.java
+++ b/android/src/main/java/com/horcrux/svg/RNSVGDefsShadowNode.java
@@ -25,12 +25,13 @@ public class RNSVGDefsShadowNode extends RNSVGDefinitionShadowNode {
                 return true;
             }
         });
-        traverseChildren(new NodeRunnable() {
+        NodeRunnable markUpdateSeenRecursive = new NodeRunnable() {
             public boolean run(RNSVGVirtualNode node) {
                 node.markUpdateSeen();
-                node.traverseChildren(NodeRunnable.this);
+                node.traverseChildren(this);
                 return true;
             }
-        });
+        };
+        traverseChildren(markUpdateSeenRecursive);
     }
 }

--- a/android/src/main/java/com/horcrux/svg/RNSVGDefsShadowNode.java
+++ b/android/src/main/java/com/horcrux/svg/RNSVGDefsShadowNode.java
@@ -25,5 +25,12 @@ public class RNSVGDefsShadowNode extends RNSVGDefinitionShadowNode {
                 return true;
             }
         });
+        traverseChildren(new NodeRunnable() {
+            public boolean run(RNSVGVirtualNode node) {
+                node.markUpdateSeen();
+                node.traverseChildren(this);
+                return true;
+            }
+        });
     }
 }


### PR DESCRIPTION
When adding clipping paths in a def and changing properties of that clipping path (or its descendants), redraw is triggered only once as updates are never marked as seen.
This change makes sure to call `markUpdateSeen` on all descendants of the Defs node on a `draw`.