### PR TITLE
Update iOS RN header paths

### DIFF
--- a/ios/Brushes/RNSVGBaseBrush.m
+++ b/ios/Brushes/RNSVGBaseBrush.m
@@ -8,7 +8,7 @@
 
 #import "RNSVGBaseBrush.h"
 #import "RCTConvert+RNSVG.h"
-#import "RCTLog.h"
+#import <React/RCTLog.h>
 
 @implementation RNSVGBaseBrush
 

--- a/ios/Brushes/RNSVGBrush.m
+++ b/ios/Brushes/RNSVGBrush.m
@@ -8,7 +8,7 @@
 
 #import "RNSVGBrush.h"
 
-#import "RCTDefines.h"
+#import <React/RCTDefines.h>
 
 @implementation RNSVGBrush
 

--- a/ios/Brushes/RNSVGPattern.m
+++ b/ios/Brushes/RNSVGPattern.m
@@ -9,7 +9,7 @@
 #import "RNSVGPattern.h"
 
 #import "RCTConvert+RNSVG.h"
-#import "RCTLog.h"
+#import <React/RCTLog.h>
 
 @implementation RNSVGPattern
 {

--- a/ios/Brushes/RNSVGSolidColorBrush.m
+++ b/ios/Brushes/RNSVGSolidColorBrush.m
@@ -9,7 +9,7 @@
 #import "RNSVGSolidColorBrush.h"
 
 #import "RCTConvert+RNSVG.h"
-#import "RCTLog.h"
+#import <React/RCTLog.h>
 
 @implementation RNSVGSolidColorBrush
 {

--- a/ios/Elements/RNSVGImage.m
+++ b/ios/Elements/RNSVGImage.m
@@ -7,9 +7,9 @@
  */
 
 #import "RNSVGImage.h"
-#import "RCTImageSource.h"
 #import "RCTConvert+RNSVG.h"
-#import "RCTLog.h"
+#import <React/RCTImageSource.h>
+#import <React/RCTLog.h>
 #import "RNSVGViewBox.h"
 
 @implementation RNSVGImage

--- a/ios/Elements/RNSVGSvgView.m
+++ b/ios/Elements/RNSVGSvgView.m
@@ -9,7 +9,7 @@
 #import "RNSVGSvgView.h"
 
 #import "RNSVGNode.h"
-#import "RCTLog.h"
+#import <React/RCTLog.h>
 
 @implementation RNSVGSvgView
 {

--- a/ios/Elements/RNSVGUse.m
+++ b/ios/Elements/RNSVGUse.m
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 #import "RNSVGUse.h"
-#import "RCTLog.h"
+#import <React/RCTLog.h>
 
 @implementation RNSVGUse
 

--- a/ios/RNSVG.xcodeproj/project.pbxproj
+++ b/ios/RNSVG.xcodeproj/project.pbxproj
@@ -514,7 +514,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)/../../react-native/React/**",
+					"$(BUILT_PRODUCTS_DIR)/usr/local/include",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = RNSVG;
@@ -528,7 +528,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)/../../react-native/React/**",
+					"$(BUILT_PRODUCTS_DIR)/usr/local/include",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = RNSVG;

--- a/ios/RNSVGNode.h
+++ b/ios/RNSVGNode.h
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import "UIView+React.h"
+#import <React/UIView+React.h>
 #import "RNSVGCGFCRule.h"
 #import "RNSVGSvgView.h"
 

--- a/ios/Shapes/RNSVGCircle.m
+++ b/ios/Shapes/RNSVGCircle.m
@@ -7,7 +7,7 @@
  */
 
 #import "RNSVGCircle.h"
-#import "RCTLog.h"
+#import <React/RCTLog.h>
 
 @implementation RNSVGCircle
 

--- a/ios/Shapes/RNSVGEllipse.m
+++ b/ios/Shapes/RNSVGEllipse.m
@@ -7,7 +7,7 @@
  */
 
 #import "RNSVGEllipse.h"
-#import "RCTLog.h"
+#import <React/RCTLog.h>
 
 @implementation RNSVGEllipse
 

--- a/ios/Shapes/RNSVGLine.m
+++ b/ios/Shapes/RNSVGLine.m
@@ -7,7 +7,7 @@
  */
 
 #import "RNSVGLine.h"
-#import "RCTLog.h"
+#import <React/RCTLog.h>
 
 @implementation RNSVGLine
 

--- a/ios/Shapes/RNSVGRect.m
+++ b/ios/Shapes/RNSVGRect.m
@@ -7,7 +7,7 @@
  */
 
 #import "RNSVGRect.h"
-#import "RCTLog.h"
+#import <React/RCTLog.h>
 
 @implementation RNSVGRect
 

--- a/ios/Utils/RCTConvert+RNSVG.h
+++ b/ios/Utils/RCTConvert+RNSVG.h
@@ -10,7 +10,7 @@
 #import "RCTConvert+RNSVG.h"
 #import "RNSVGCGFloatArray.h"
 #import "RNSVGTextFrame.h"
-#import "RCTConvert.h"
+#import <React/RCTConvert.h>
 #import "RNSVGCGFCRule.h"
 
 @class RNSVGBrush;

--- a/ios/Utils/RCTConvert+RNSVG.m
+++ b/ios/Utils/RCTConvert+RNSVG.m
@@ -11,10 +11,10 @@
 #import "RNSVGBaseBrush.h"
 #import "RNSVGPattern.h"
 #import "RNSVGSolidColorBrush.h"
-#import "RCTLog.h"
+#import <React/RCTLog.h>
 #import "RNSVGCGFCRule.h"
 #import "RNSVGVBMOS.h"
-#import "RCTFont.h"
+#import <React/RCTFont.h>
 
 @implementation RCTConvert (RNSVG)
 

--- a/ios/ViewManagers/RNSVGDefsManager.h
+++ b/ios/ViewManagers/RNSVGDefsManager.h
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 
 @interface RNSVGDefsManager : RCTViewManager
 

--- a/ios/ViewManagers/RNSVGNodeManager.h
+++ b/ios/ViewManagers/RNSVGNodeManager.h
@@ -7,7 +7,7 @@
  */
 
 #import "RNSVGNode.h"
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 
 @interface RNSVGNodeManager : RCTViewManager
 

--- a/ios/ViewManagers/RNSVGSvgViewManager.h
+++ b/ios/ViewManagers/RNSVGSvgViewManager.h
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 
 @interface RNSVGSvgViewManager : RCTViewManager
 

--- a/ios/ViewManagers/RNSVGSvgViewManager.m
+++ b/ios/ViewManagers/RNSVGSvgViewManager.m
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import "RCTBridge.h"
-#import "RCTUIManager.h"
+#import <React/RCTBridge.h>
+#import <React/RCTUIManager.h>
 #import "RNSVGSvgViewManager.h"
 #import "RNSVGSvgView.h"
 


### PR DESCRIPTION
https://github.com/facebook/react-native/commit/e1577df1fd70049ce7f288f91f6e2b18d512ff4d moves header imports to `<React/*>`. This updates header include path and all imports so build works against react master (soon to be version 0.40.0).

TODO: Update examples when RN 0.40 is out.