### PR TITLE
Add measure function CSSNode to fix error in RN 0.39

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RNSVGSvgViewManager.java
+++ b/android/src/main/java/com/horcrux/svg/RNSVGSvgViewManager.java
@@ -11,6 +11,9 @@ package com.horcrux.svg;
 
 import android.graphics.Bitmap;
 
+import com.facebook.csslayout.CSSMeasureMode;
+import com.facebook.csslayout.CSSNodeAPI;
+import com.facebook.csslayout.MeasureOutput;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.BaseViewManager;
@@ -29,6 +32,17 @@ public class RNSVGSvgViewManager extends BaseViewManager<RNSVGSvgView, RNSVGSvgV
 
     private static final String REACT_CLASS = "RNSVGSvgView";
     private static final int COMMAND_TO_DATA_URL = 100;
+    private static final CSSNodeAPI.MeasureFunction MEASURE_FUNCTION = new CSSNodeAPI.MeasureFunction() {
+        @Override
+        public long measure(
+                CSSNodeAPI node,
+                float width,
+                CSSMeasureMode widthMode,
+                float height,
+                CSSMeasureMode heightMode) {
+            throw new IllegalStateException("SvgView should have explicit width and height set");
+        }
+    };
 
     @Override
     public String getName() {
@@ -42,7 +56,9 @@ public class RNSVGSvgViewManager extends BaseViewManager<RNSVGSvgView, RNSVGSvgV
 
     @Override
     public RNSVGSvgViewShadowNode createShadowNodeInstance() {
-        return new RNSVGSvgViewShadowNode();
+        RNSVGSvgViewShadowNode node = new RNSVGSvgViewShadowNode();
+        node.setMeasureFunction(MEASURE_FUNCTION);
+        return node;
     }
 
     @Override


### PR DESCRIPTION
RN Android 0.39 now uses the C based css-layout and it crashes with an error that says that you cannot attach a CSS node without a measure function. The change is based on RN ART and just adds a dummy measure function to fix the issue (see https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/views/art/ARTSurfaceViewManager.java#L48).