### PR TITLE
illustrator compatibility for polyline and polygon elements

### DIFF
--- a/elements/Polygon.js
+++ b/elements/Polygon.js
@@ -3,6 +3,11 @@ import Path from './Path';
 import {pathProps} from '../lib/props';
 import _ from 'lodash';
 
+// ALLOWS LIST OF COORDS SEPARATED BY SPACE OR COMPACTED DUE TO NEGATIVE SIGN
+// SIMPLIFIES IMPORTING OF ILLUSTRATOR GENERATED POLYGON WITHOUT ANY FURTHER MODIFIATION
+
+const normalize = function(points) { return points.replace('-',' -').split(/[ ,]/).map((p,i) => { return i%2==1 ? ',' + p : i > 0 ? ' '+p : p}).join('') }
+
 class Polygon extends Component{
     static displayName = 'Polygon';
     static propTypes = {
@@ -22,6 +27,8 @@ class Polygon extends Component{
         let points = this.props.points;
         if (_.isArray(points)) {
             points = points.join(',');
+        } else {
+          points = normalize(points);
         }
 
         return <Path

--- a/elements/Polyline.js
+++ b/elements/Polyline.js
@@ -3,6 +3,11 @@ import Path from './Path';
 import {pathProps} from '../lib/props';
 import _ from 'lodash';
 
+// ALLOWS LIST OF COORDS SEPARATED BY SPACE OR COMPACTED DUE TO NEGATIVE SIGN
+// SIMPLIFIES IMPORTING OF ILLUSTRATOR GENERATED POLYLINE WITHOUT ANY FURTHER MODIFIATION
+
+const normalize = function(points) { return points.replace('-',' -').split(/[ ,]/).map((p,i) => { return i%2==1 ? ',' + p : i > 0 ? ' '+p : p}).join('') }
+
 class Polyline extends Component{
     static displayName = 'Polyline';
     static propTypes = {
@@ -22,6 +27,8 @@ class Polyline extends Component{
         let points = this.props.points;
         if (_.isArray(points)) {
             points = points.join(',');
+        } else {
+            points = normalize(points);
         }
 
         return <Path


### PR DESCRIPTION
The svg generated from illustrator has a flat list of points without any commas separating the points. This change takes care of the parsing for illustrator generated format, reducing the need for manual change of the point specification.