### PR TITLE
Replace RNSVGBrushConverter type with RNSVGPainter

### DIFF
--- a/ios/Brushes/RNSVGPattern.m
+++ b/ios/Brushes/RNSVGPattern.m
@@ -39,7 +39,7 @@
 // Note: This could use applyFillColor with a pattern. This could be more efficient but
 // to do that, we need to calculate our own user space CTM.
 
-- (void)paint:(CGContextRef)context opacity:(CGFloat)opacity brushConverter:(RNSVGBrushConverter *)brushConverter;
+- (void)paint:(CGContextRef)context opacity:(CGFloat)opacity brushConverter:(RNSVGPainter *)brushConverter;
 {
   CGContextDrawTiledImage(context, _rect, _image);
 }


### PR DESCRIPTION
This modification was made in cfaca8b3cb166207357b7b945151762db81d3053, but was missing in a private method signature inside RNSVGPattern.m.