### PR TITLE
Add Blend Modes for iOS

### DIFF
--- a/ios/RNSVGRenderable.h
+++ b/ios/RNSVGRenderable.h
@@ -18,6 +18,7 @@
 
 @property (nonatomic, strong) RNSVGBrush *fill;
 @property (nonatomic, assign) CGFloat fillOpacity;
+@property (nonatomic, assign) CGBlendMode blendMode;
 @property (nonatomic, assign) RNSVGCGFCRule fillRule;
 @property (nonatomic, strong) RNSVGBrush *stroke;
 @property (nonatomic, assign) CGFloat strokeOpacity;

--- a/ios/RNSVGRenderable.m
+++ b/ios/RNSVGRenderable.m
@@ -23,6 +23,7 @@
         _strokeOpacity = 1;
         _strokeWidth = 1;
         _fillRule = kRNSVGCGFCRuleNonzero;
+        _blendMode = kCGBlendModeNormal;
     }
     return self;
 }
@@ -139,6 +140,15 @@
     [self invalidate];
 }
 
+- (void)setBlendMode:(CGBlendMode)blendMode
+{
+    if (blendMode == _blendMode) {
+        return;
+    }
+    _blendMode = blendMode;
+    [self invalidate];
+}
+
 - (void)dealloc
 {
     CGPathRelease(_hitArea);
@@ -153,6 +163,7 @@
     CGContextSaveGState(context);
     CGContextConcatCTM(context, self.matrix);
     CGContextSetAlpha(context, self.opacity);
+    CGContextSetBlendMode(context, self.blendMode);
     
     [self beginTransparencyLayer:context];
     [self renderLayerTo:context];

--- a/ios/Utils/RCTConvert+RNSVG.h
+++ b/ios/Utils/RCTConvert+RNSVG.h
@@ -31,5 +31,6 @@
 + (CGRect)RNSVGCGRect:(id)json offset:(NSUInteger)offset;
 + (CGColorRef)RNSVGCGColor:(id)json offset:(NSUInteger)offset;
 + (CGGradientRef)RNSVGCGGradient:(id)json offset:(NSUInteger)offset;
++ (CGBlendMode)CGBlendMode:(id)json;
 
 @end

--- a/ios/Utils/RCTConvert+RNSVG.m
+++ b/ios/Utils/RCTConvert+RNSVG.m
@@ -130,4 +130,18 @@ RCT_ENUM_CONVERTER(RNSVGUnits, (@{
     return (CGGradientRef)CFAutorelease(gradient);
 }
 
++ (CGBlendMode)CGBlendMode:(id)json
+{
+    if (!json) {
+        return nil;
+    }
+    NSNumber* mode = [self NSNumber:json];
+    int32_t value = [mode intValue];
+    if (value >= kCGBlendModeNormal && value <= kCGBlendModePlusLighter) {
+        return (CGBlendMode)value;
+    } else {
+        return kCGBlendModeNormal;
+    }
+}
+
 @end

--- a/ios/ViewManagers/RNSVGRenderableManager.m
+++ b/ios/ViewManagers/RNSVGRenderableManager.m
@@ -31,6 +31,7 @@ RCT_EXPORT_VIEW_PROPERTY(strokeLinejoin, CGLineJoin)
 RCT_EXPORT_VIEW_PROPERTY(strokeDasharray, RNSVGCGFloatArray)
 RCT_EXPORT_VIEW_PROPERTY(strokeDashoffset, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(strokeMiterlimit, CGFloat)
+RCT_EXPORT_VIEW_PROPERTY(blendMode, CGBlendMode)
 RCT_EXPORT_VIEW_PROPERTY(propList, NSArray<NSString *>)
 
 @end

--- a/lib/attributes.js
+++ b/lib/attributes.js
@@ -43,6 +43,7 @@ const NodeAttributes = {
     opacity: true,
     clipRule: true,
     clipPath: true,
+    //blendMode: true,
     propList: {
         diff: arrayDiffer
     },
@@ -69,7 +70,13 @@ const FillAndStrokeAttributes = {
     strokeMiterlimit: true
 };
 
+
+const BlendModeAttributes = {
+    blendMode: true
+};
+
 const RenderableAttributes = {
+    ...BlendModeAttributes,
     ...NodeAttributes,
     ...FillAndStrokeAttributes
 };

--- a/lib/extract/extractBlendMode.js
+++ b/lib/extract/extractBlendMode.js
@@ -1,0 +1,35 @@
+
+const blendModes = {
+    'normal':           0,
+    'multiply':         1,
+    'screen':           2,
+    'overlay':          3,
+    'darken':           4,
+    'lighten':          5,
+    'color-dodge':      6,
+    'color-burn':       7,
+    'soft-light':       8,
+    'hard-light':       9,
+    'difference':       10,
+    'exclusion':        11,
+    'hue':              12,
+    'saturation':       13,
+    'color':            14,
+    'luminosity':       15,
+    'clear':            16,
+    'copy':             17,
+    'source-in':        18,
+    'source-out':       19,
+    'source-atop':      20,
+    'destination-over': 21,
+    'destination-in':   22,
+    'destination-out':  23,
+    'destination-atop': 24,
+    'xor':              25,
+    'plus-darker':      26,
+    'plus-lighter':     27,
+};
+
+export default function(blendMode) {
+    return +blendModes[blendMode];
+}

--- a/lib/extract/extractBlendMode.js
+++ b/lib/extract/extractBlendMode.js
@@ -31,5 +31,5 @@ const blendModes = {
 };
 
 export default function(blendMode) {
-    return +blendModes[blendMode];
+    return blendModes[blendMode] || 0;
 }

--- a/lib/extract/extractProps.js
+++ b/lib/extract/extractProps.js
@@ -4,12 +4,14 @@ import extractTransform from './extractTransform';
 import extractClipPath from './extractClipPath';
 import extractResponder from './extractResponder';
 import extractOpacity from './extractOpacity';
+import extractBlendMode from './extractBlendMode';
 
 export default function(props, ref) {
     const styleProperties = [];
 
     const extractedProps = {
         opacity: extractOpacity(props.opacity),
+        blendMode: extractBlendMode(props.blendMode),
         propList: styleProperties
     };
 

--- a/lib/props.js
+++ b/lib/props.js
@@ -76,6 +76,10 @@ const transformProps = {
     transform: PropTypes.object
 };
 
+const blendProps = {
+    blendMode: PropTypes.string
+};
+
 const pathProps = {
     ...fillProps,
     ...strokeProps,
@@ -83,7 +87,8 @@ const pathProps = {
     ...transformProps,
     ...responderProps,
     ...touchableProps,
-    ...definationProps
+    ...definationProps,
+    ...blendProps
 };
 
 export {
@@ -94,5 +99,6 @@ export {
     clipProps,
     pathProps,
     responderProps,
-    touchableProps
+    touchableProps,
+    blendProps
 };


### PR DESCRIPTION
It's just one part of feature (iOS-only).

#### TODO:
- implement SVGFEBlendElement
- Android implementation

#### Example of usage:
```
<Circle
      cx=’50’
      cy=’50’
      r=‘100’
      fill='rgb(127, 127, 127)'
      blendMode='color-burn'
 />
```

#### Possible values:

- normal
- multiply        
- screen          
- overlay         
- darken          
- lighten         
- color-dodge     
- color-burn      
- soft-light      
- hard-light      
- difference      
- exclusion       
- hue             
- saturation      
- color           
- luminosity      
- clear           
- copy            
- source-in       
- source-out      
- source-atop     
- destination-over
- destination-in  
- destination-out
- destination-atop
- xor             
- plus-darker     
- plus-lighter