### PR TITLE
Add manual Android instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 ### Installation
 
+#### Automatic
+
 *With Exponent, this is pre-installed. Jump ahead to [Usage](#Usage)*
 
 1. Install library from `npm`
@@ -42,6 +44,30 @@
     ```bash
     rnpm link react-native-svg
     ```
+    
+#### Manual
+
+##### Android
+
+1. `npm install react-native-svg --save`
+
+2. Append the following lines to `android/settings.gradle`:
+
+	```
+	include ':react-native-svg'
+	project(':react-native-svg').projectDir = new File(rootProject.projectDir, 	'./node_modules/react-native-svg/android')
+	```
+    
+3. Insert the following lines inside the dependencies block in `android/app/build.gradle`:
+
+	```
+    compile project(':react-native-svg')
+	```
+
+4. Open up `android/app/src/main/java/[...]/MainApplication.java
+  - Add `import com.horcrux.svg.SvgPackage;` to the imports at the top of the file
+  - Add `new SvgPackage()` to the list returned by the `getPackages()` method. Add a comma to the previous item if there's already something there.
+  
 
 ### <a name="Usage">Usage</a>
 


### PR DESCRIPTION
Especially important when integrating React Native into existing applications that rnpm or react-native link don't work.