### PR TITLE
Added feature to not relay on having commas for Polygons points to work

### DIFF
--- a/elements/Polygon.js
+++ b/elements/Polygon.js
@@ -18,15 +18,19 @@ export default class extends Component{
     };
 
     render() {
-        let points = this.props.points;
-        if (Array.isArray(points)) {
-            points = points.join(',');
+        const points = this.props.points.replace(/,+/g, ' ').trim().split(' ')
+
+        for (let i = 0; i < points.length; i += 2) {
+          points[i] += ',';
+          points[i+1] += ' ';
         }
+
+        const pointsStr = points.join('');
 
         return <Path
             ref={ele => {this.root = ele;}}
             {...this.props}
-            d={`M${points.trim().replace(/\s+/g, 'L')}z`}
+            d={`M${pointsStr.trim().replace(/\s+/g, 'L')}z`}
         />;
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "5.1.6",
+    "version": "5.2.0",
     "name": "react-native-svg",
     "description": "SVG library for react-native",
     "repository": {


### PR DESCRIPTION
Currently `Polygon.js` only accepts points with comma format, like:
`<Polygon points="40,5 70,80 25,95"/>`
  
This PR includes the possibility to write points as you wish (with commas, without or misc):
E.g:
```
<Polygon points="40 5   70,80 25 95"/>
<Polygon points="40   5 70   80 25        95"/>
<Polygon points="40,5 70,80 25,95"/>
```