### PR TITLE
Respect responsible flag of RNSVGNode.

### DIFF
--- a/ios/RNSVGRenderable.m
+++ b/ios/RNSVGRenderable.m
@@ -249,7 +249,7 @@
 - (void)setHitArea:(CGPathRef)path
 {
     CGPathRelease(_hitArea);
-    if ([self getSvgView].responsible) {
+    if (self.responsible) {
         // Add path to hitArea
         CGMutablePathRef hitArea = CGPathCreateMutableCopy(path);
         


### PR DESCRIPTION
**Motivation**
RNSVGNode without 'pointerEvents' consumes touch events of underlying nodes, because the hitArea is added, even if the responsible flag of the node is set to false.

**Fix**
Check for the responsible flag of the node itself instead of the underlying svgView whose responsible flag is true, if any containing node has 'pointerEvents'.