### PR TITLE
Fix polypoints RegExp

### DIFF
--- a/lib/extract/extractPolyPoints.js
+++ b/lib/extract/extractPolyPoints.js
@@ -1,4 +1,4 @@
 
 export default function (polyPoints) {
-    return polyPoints.replace(/-/, ' -').split(/(?:\s+|\s*,\s*)/g).join(' ');
+    return polyPoints.split(/(?:\s+|\s*,\s*)/g).join(' ');
 }


### PR DESCRIPTION
Remove ".replace(/-/, ' -')", because if you use scientific notation like "1e-19' of float number, this will cause extra space and the number will be divided to two part.
