### PR TITLE
Fix setNativeProps for all elements that inherit from Shape.  

### DIFF
--- a/elements/Circle.js
+++ b/elements/Circle.js
@@ -21,10 +21,6 @@ export default class extends Shape {
         r: 0
     };
 
-    setNativeProps = (...args) => {
-        this.root.setNativeProps(...args);
-    };
-
     render() {
         let props = this.props;
         return <RNSVGCircle

--- a/elements/Ellipse.js
+++ b/elements/Ellipse.js
@@ -23,10 +23,6 @@ export default class extends Shape{
         ry: 0
     };
 
-    setNativeProps = (...args) => {
-        this.root.setNativeProps(...args);
-    };
-
     render() {
         let props = this.props;
 

--- a/elements/G.js
+++ b/elements/G.js
@@ -10,10 +10,6 @@ export default class extends Shape{
 
     static propTypes = pathProps;
 
-    setNativeProps = (...args) => {
-        this.root.setNativeProps(...args);
-    };
-
     render() {
         let {props} = this;
 

--- a/elements/Image.js
+++ b/elements/Image.js
@@ -31,10 +31,6 @@ export default class extends Shape {
         preserveAspectRatio: 'xMidYMid meet'
     };
 
-    setNativeProps = (...args) => {
-        this.root.setNativeProps(...args);
-    };
-
     render() {
         let {props} = this;
         let modes = props.preserveAspectRatio.trim().split(spacesRegExp);

--- a/elements/Line.js
+++ b/elements/Line.js
@@ -23,10 +23,6 @@ export default class extends Shape {
         y2: 0
     };
 
-    setNativeProps = (...args) => {
-        this.root.setNativeProps(...args);
-    };
-
     render() {
         let props = this.props;
         return <RNSVGLine

--- a/elements/Path.js
+++ b/elements/Path.js
@@ -13,10 +13,6 @@ export default class extends Shape {
         d: PropTypes.string.isRequired
     };
 
-    setNativeProps = (...args) => {
-        this.root.setNativeProps(...args);
-    };
-
     render() {
         let props = this.props;
 

--- a/elements/Polygon.js
+++ b/elements/Polygon.js
@@ -14,10 +14,6 @@ export default class extends Component{
         points: ''
     };
 
-    setNativeProps = (...args) => {
-        this.root.getNativeElement().setNativeProps(...args);
-    };
-
     render() {
         let points = this.props.points;
         if (Array.isArray(points)) {

--- a/elements/Rect.js
+++ b/elements/Rect.js
@@ -28,10 +28,6 @@ export default class extends Shape {
         ry: 0
     };
 
-    setNativeProps = (...args) => {
-        this.root.setNativeProps(...args);
-    };
-
     render() {
         let props = this.props;
 

--- a/elements/Shape.js
+++ b/elements/Shape.js
@@ -1,5 +1,6 @@
 import {Component} from 'react';
 import SvgTouchableMixin from '../lib/SvgTouchableMixin';
+import extractProps from '../lib/extract/extractProps';
 import _ from 'lodash';
 
 class Shape extends Component {
@@ -10,6 +11,17 @@ class Shape extends Component {
         });
         this.state = this.touchableGetInitialState();
     }
+
+    setNativeProps = (args) => {
+        var extracted = extractProps(args, this)
+        for(var key in args) {
+          if (extracted[key]) {
+            args[key] = extracted[key]
+          }
+        }
+        this.root.setNativeProps(args);
+    };
+
 }
 
 export default Shape;

--- a/elements/TSpan.js
+++ b/elements/TSpan.js
@@ -34,10 +34,6 @@ export default class extends Shape {
         };
     };
 
-    setNativeProps = (...args) => {
-        this.root.setNativeProps(...args);
-    };
-
     render() {
         let props = this.props;
         return <RNSVGTSpan

--- a/elements/Text.js
+++ b/elements/Text.js
@@ -33,10 +33,6 @@ export default class extends Shape {
         };
     };
 
-    setNativeProps = (...args) => {
-        this.root.setNativeProps(...args);
-    };
-
     render() {
         const props = this.props;
 

--- a/elements/Use.js
+++ b/elements/Use.js
@@ -16,10 +16,6 @@ export default class extends Shape {
         ...pathProps
     };
 
-    setNativeProps = (...args) => {
-        this.root.setNativeProps(...args);
-    };
-
     render() {
         const {props} = this;
         // match "url(#pattern)"


### PR DESCRIPTION
The native props being set were not passing through extractProps, leading to various mismatches in the values. 

More discussion here:
https://github.com/react-native-community/react-native-svg/issues/180 

And here:
https://github.com/react-native-community/react-native-svg/issues/326