### PR TITLE
Fixed "viewbox" casing in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ The SVG <Symbol> element is used to define reusable symbols. The shapes nested i
     height="150"
     width="110"
 >
-    <Symbol id="symbol" viewbox="0 0 150 110" width="100" height="50">
+    <Symbol id="symbol" viewBox="0 0 150 110" width="100" height="50">
         <Circle cx="50" cy="50" r="40" strokeWidth="8" stroke="red" fill="red"/>
         <Circle cx="90" cy="60" r="40" strokeWidth="8" stroke="green" fill="white"/>
     </Symbol>


### PR DESCRIPTION
Casing is important for properties. "viewbox" does nothing while "viewBox" works.