### PR TITLE
Replace yoga's YogaNodeAPI with YogaNode

### DIFF
--- a/android/src/main/java/com/horcrux/svg/SvgViewManager.java
+++ b/android/src/main/java/com/horcrux/svg/SvgViewManager.java
@@ -14,7 +14,7 @@ import android.util.SparseArray;
 
 import com.facebook.yoga.YogaMeasureMode;
 import com.facebook.yoga.YogaMeasureFunction;
-import com.facebook.yoga.YogaNodeAPI;
+import com.facebook.yoga.YogaNode;
 import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 
@@ -31,7 +31,7 @@ public class SvgViewManager extends BaseViewManager<SvgView, SvgViewShadowNode> 
     private static final YogaMeasureFunction MEASURE_FUNCTION = new YogaMeasureFunction() {
         @Override
         public long measure(
-                YogaNodeAPI node,
+                YogaNode node,
                 float width,
                 YogaMeasureMode widthMode,
                 float height,


### PR DESCRIPTION
Fixes https://github.com/react-native-community/react-native-svg/issues/340. I imagine this will be a breaking change for react-native versions < 0.45.0.