### PR TITLE
Fix clipPath animations

### DIFF
--- a/android/src/main/java/com/horcrux/svg/VirtualNode.java
+++ b/android/src/main/java/com/horcrux/svg/VirtualNode.java
@@ -145,7 +145,7 @@ public abstract class VirtualNode extends LayoutShadowNode {
     }
 
     protected @Nullable Path getClipPath(Canvas canvas, Paint paint) {
-        if (mClipPath != null && mCachedClipPath == null) {
+        if (mClipPath != null) {
             VirtualNode node = getSvgShadowNode().getDefinedClipPath(mClipPath);
 
             if (node != null) {

--- a/ios/RNSVGNode.m
+++ b/ios/RNSVGNode.m
@@ -117,7 +117,7 @@
 
 - (CGPathRef)getClipPath:(CGContextRef)context
 {
-    if (self.clipPath && !_cachedClipPath) {
+    if (self.clipPath) {
         CGPathRelease(_cachedClipPath);
         _cachedClipPath = CGPathRetain([[[self getSvgView] getDefinedClipPath:self.clipPath] getPath:context]);
     }


### PR DESCRIPTION
Fix for issue #251.
Since the refactor, the clip path is created just once and cached until the nodes are recreated.
If you animate any of the clip path elements, the cached clip path is always used and nothing animates.
The solution is to recreate the clip path on every getClipPath call during a draw phase. We can use the cached clip path during a hitTest, I did not change that.