### PR TITLE
replace yoganode with yoganodeapi

### DIFF
--- a/android/src/main/java/com/horcrux/svg/SvgViewManager.java
+++ b/android/src/main/java/com/horcrux/svg/SvgViewManager.java
@@ -14,7 +14,7 @@ import android.util.SparseArray;
 
 import com.facebook.yoga.YogaMeasureMode;
 import com.facebook.yoga.YogaMeasureFunction;
-import com.facebook.yoga.YogaNode;
+import com.facebook.yoga.YogaNodeAPI;
 import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 
@@ -31,7 +31,7 @@ public class SvgViewManager extends BaseViewManager<SvgView, SvgViewShadowNode> 
     private static final YogaMeasureFunction MEASURE_FUNCTION = new YogaMeasureFunction() {
         @Override
         public long measure(
-                YogaNode node,
+                YogaNodeAPI node,
                 float width,
                 YogaMeasureMode widthMode,
                 float height,


### PR DESCRIPTION
Fix "method does not override or implement a method from a supertype" in SvgViewManager class for version 5.2.0.
