### PR TITLE
Correct matrix typo

### DIFF
--- a/lib/Matrix2D.js
+++ b/lib/Matrix2D.js
@@ -83,7 +83,7 @@ export default class Matrix2D {
         this.a = a == null ? 1 : a;
         this.b = b || 0;
         this.c = c || 0;
-        this.d = b == null ? 1 : d;
+        this.d = d == null ? 1 : d;
         this.tx = tx || 0;
         this.ty = ty || 0;
         return this;


### PR DESCRIPTION
I believe this is a typo, introduced here: https://github.com/react-native-community/react-native-svg/commit/5bd9b40c1725b60f5a034ce5488c488393356593#diff-53fd7ef0f8293582e3a5625fe345b1f9R86