### PR TITLE
Remove react-native from dependencies list

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     },
     "dependencies": {
         "color": "^0.11.1",
-        "lodash": "^4.16.6",
-        "react-native": "^0.45.0"
+        "lodash": "^4.16.6"
     },
     "devDependencies": {
         "babel-eslint": "^6.1.2",


### PR DESCRIPTION
caaadd3621dc5c0e996b52620fd525dbec427e36 mistakenly added `react-native` as a dependency of the package. This causes package managers to download `react-native`, which then conflicts with the `react-native` at the root of a React Native app. The haste-mapping packager distributed with React Native complains accordingly.

This fixes #361.

