### PR TITLE
Remove react-native from dependencies (only should be peerDep)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     },
     "dependencies": {
         "color": "^0.11.1",
-        "lodash": "^4.16.6",
-        "react-native": "^0.45.0"
+        "lodash": "^4.16.6"
     },
     "devDependencies": {
         "babel-eslint": "^6.1.2",


### PR DESCRIPTION
RN libraries should almost never depend on react-native and just specify it as a peerDep.