### PR TITLE
Fix image layout iOS [#312 #313]

### DIFF
--- a/ios/Elements/RNSVGImage.m
+++ b/ios/Elements/RNSVGImage.m
@@ -126,6 +126,7 @@
     
     CGRect vbRect = CGRectMake(0, 0, CGRectGetWidth(renderRect), CGRectGetHeight(renderRect));
     CGRect eRect = CGRectMake([self getContextLeft], [self getContextTop], rectWidth, rectHeight);
+    CGContextTranslateCTM(context, CGRectGetMinX(eRect), 0.0f);
     
     CGAffineTransform transform = [RNSVGViewBox getTransform:vbRect eRect:eRect align:self.align meetOrSlice:self.meetOrSlice fromSymbol:NO];
     

--- a/ios/Elements/RNSVGImage.m
+++ b/ios/Elements/RNSVGImage.m
@@ -133,7 +133,6 @@
     renderRect = CGRectApplyAffineTransform(renderRect, CGAffineTransformMakeTranslation(rectX, rectY));
     
     [self clip:context];
-    CGContextClipToRect(context, rect);
  
     CGContextDrawImage(context, renderRect, _image);
     CGContextRestoreGState(context);

--- a/ios/Elements/RNSVGImage.m
+++ b/ios/Elements/RNSVGImage.m
@@ -126,12 +126,12 @@
     
     CGRect vbRect = CGRectMake(0, 0, CGRectGetWidth(renderRect), CGRectGetHeight(renderRect));
     CGRect eRect = CGRectMake([self getContextLeft], [self getContextTop], rectWidth, rectHeight);
+    eRect.origin.y = 0.0f;
     CGContextTranslateCTM(context, CGRectGetMinX(eRect), 0.0f);
     
     CGAffineTransform transform = [RNSVGViewBox getTransform:vbRect eRect:eRect align:self.align meetOrSlice:self.meetOrSlice fromSymbol:NO];
     
     renderRect = CGRectApplyAffineTransform(renderRect, transform);
-    renderRect = CGRectApplyAffineTransform(renderRect, CGAffineTransformMakeTranslation(rectX, rectY));
     
     [self clip:context];
  

--- a/ios/Utils/RNSVGViewBox.m
+++ b/ios/Utils/RNSVGViewBox.m
@@ -39,10 +39,10 @@
     CGFloat scaleY = eHeight / vbHeight;
     
     
-    // Initialize translate-x to vb-x - e-x.
-    // Initialize translate-y to vb-y - e-y.
-    CGFloat translateX = vbX - eX;
-    CGFloat translateY = vbY - eY;
+    // Initialize translate-x to e-x - (vb-x * scale-x).
+    // Initialize translate-y to e-y - (vb-y * scale-y).
+    CGFloat translateX = eX - (vbX * scaleX);
+    CGFloat translateY = eY - (vbY * scaleY);
     
     // If align is 'none'
     if (meetOrSlice == kRNSVGVBMOSNone) {

--- a/ios/Utils/RNSVGViewBox.m
+++ b/ios/Utils/RNSVGViewBox.m
@@ -69,24 +69,24 @@
             scaleX = scaleY = fmax(scaleX, scaleY);
         }
         
-        // If align contains 'xMid', minus (e-width / scale-x - vb-width) / 2 from transform-x.
+        // If align contains 'xMid', add (e-width - vb-width * scale-x) / 2 to translate-x.
         if ([align containsString:@"xMid"]) {
-            translateX -= (eWidth / scaleX - vbWidth) / 2;
+            translateX += (eWidth - vbWidth * scaleX) / 2.0f;
         }
         
-        // If align contains 'xMax', minus (e-width / scale-x - vb-width) from transform-x.
+        // If align contains 'xMax', add (e-width - vb-width * scale-x) to translate-x.
         if ([align containsString:@"xMax"]) {
-            translateX -= eWidth / scaleX - vbWidth;
+            translateX += (eWidth - vbWidth * scaleX);
         }
         
-        // If align contains 'yMid', minus (e-height / scale-y - vb-height) / 2 from transform-y.
+        // If align contains 'yMid', add (e-height - vb-height * scale-y) / 2 to translate-y.
         if ([align containsString:@"YMid"]) {
-            translateY -= (eHeight / scaleY - vbHeight) / 2;
+            translateY += (eHeight - vbHeight * scaleY) / 2.0f;
         }
         
-        // If align contains 'yMax', minus (e-height / scale-y - vb-height) from transform-y.
+        // If align contains 'yMax', add (e-height - vb-height * scale-y) to translate-y.
         if ([align containsString:@"YMax"]) {
-            translateY -= eHeight / scaleY - vbHeight;
+            translateY += (eHeight - vbHeight * scaleY);
         }
     }
     


### PR DESCRIPTION
Fixes the issue with image translation on iOS, as brought up in issues #312 and #313 

This fix has worked so far on examples I've tested it with, though I'm unclear as to what was the original intention for the `CGContextClipToRect(context, rect);` on line 136 in `RNSVGImage.m`. I removed it because it's causing the image to be clipped to its starting coordinate and size (so if the image is translated or scaled it will end up being cropped). But as I'm not sure why it was there originally, this change might cause some other issue? If it was there to handle some case, please let me know and I can fix that up.
