### PR TITLE
implement createJSModules method in SvgPackge

### DIFF
--- a/android/src/main/java/com/horcrux/svg/SvgPackage.java
+++ b/android/src/main/java/com/horcrux/svg/SvgPackage.java
@@ -45,6 +45,11 @@ public class SvgPackage implements ReactPackage {
     }
 
     @Override
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
+    }
+
+    @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         return Collections.<NativeModule>singletonList(new SvgViewModule(reactContext));
     }


### PR DESCRIPTION
createJSModules was deleted in commit 26bbc1c3180a9486ad16cc5a5be96e02eb705479. this caused the bug described in issue #412 