### PR TITLE
fix broken multi touch for Android (#432)

### DIFF
--- a/android/src/main/java/com/horcrux/svg/SvgView.java
+++ b/android/src/main/java/com/horcrux/svg/SvgView.java
@@ -148,6 +148,7 @@ public class SvgView extends View {
             // this gesture.
             dispatch(ev, TouchEventType.END);
             mTargetTag = -1;
+            mGestureStartTime = TouchEvent.UNSET;
         } else if (action == MotionEvent.ACTION_MOVE) {
             // Update pointer position for current gesture
             dispatch(ev, TouchEventType.MOVE);
@@ -157,8 +158,6 @@ public class SvgView extends View {
         } else if (action == MotionEvent.ACTION_POINTER_UP) {
             // Exactly onw of the pointers goes up
             dispatch(ev, TouchEventType.END);
-            mTargetTag = -1;
-            mGestureStartTime = TouchEvent.UNSET;
         } else if (action == MotionEvent.ACTION_CANCEL) {
             dispatchCancelEvent(ev);
             mTargetTag = -1;


### PR DESCRIPTION
This is a fix for (#432).

On Android, when completing a multi touch gesture, `handleTouchEvent` is called multiple times with `ACTION_POINTER_UP` - once for each touch pointer. If the first time `mGestureStartTime` is unset, then subsequent calls crash, because they need the start time.

See (#432) for the stack trace of the crash.