### PR TITLE
Add "react" to devDeps, set peerDep version to "*", run tests on Node 6 & 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ sudo: false
 
 language: node_js
 node_js:
-  - '5'
-  - '4'
-  - '0.12'
+  - '8'
+  - '6'
 
 script:
   - npm run lint

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "peerDependencies": {
         "react-native": ">=0.46.0",
-        "react": "16.0.0-alpha.12",
+        "react": "*",
         "prop-types": "^15.5.8"
     },
     "dependencies": {
@@ -34,7 +34,8 @@
         "babel-eslint": "^6.1.2",
         "eslint": "^2.13.1",
         "eslint-plugin-react": "^4.3.0",
-        "react-native": "^0.46.0"
+        "react-native": "^0.49.0",
+        "react": "16.0.0-beta.5"
     },
     "nativePackage": true
 }


### PR DESCRIPTION
RN 0.48 uses alpha 12, 0.49 uses beta 5, and 0.50 uses 16.0.0. "*" covers everything and "react-native" specifies what peerDep version it wants anyway.

"react" is listed under devDeps so that we get the correct version for testing.

CI: RN's own tests don't run on Node 4 anymore, test just 6 and 8.