### PR TITLE
Fix tag mismatch in podspec

### DIFF
--- a/RNSVG.podspec
+++ b/RNSVG.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.license          = package['license']
   s.homepage         = 'https://github.com/magicismight/react-native-svg'
   s.authors          = 'Horcrux Chen'
-  s.source           = { :git => 'https://github.com/magicismight/react-native-svg.git', :tag => "v#{s.version}" }
+  s.source           = { :git => 'https://github.com/magicismight/react-native-svg.git', :tag => s.version }
   s.source_files     = 'ios/**/*.{h,m}'
   s.requires_arc     = true
   s.platforms        = { :ios => "8.0", :tvos => "9.2" }


### PR DESCRIPTION
The tags for this repo *usually* dont have a `v` prefix, so doing a `pod install` with a direct dependency on the podspec fails.

e.g

`pod 'RNSVG', :podspec => 'node_modules/react-native-svg/RNSVG.podspec'` will fail due to the podspec assuming that the git tag has a `v` prefix

The alternative (and better solution) is to update the old git tags to add `v` prefixes, as this will retroactively fix this bug for all versions since 4.1.0.

But I cant fix tags with pull requests, so I could do with some help here.