### PR TITLE
Fix for RN 0.50

### DIFF
--- a/elements/Circle.js
+++ b/elements/Circle.js
@@ -37,9 +37,7 @@ export default class extends Shape {
     }
 }
 
-
-
-const RNSVGCircle = createReactNativeComponentClass({
+const RNSVGCircle = createReactNativeComponentClass('RNSVGCircle', () => ({
     validAttributes: CircleAttributes,
     uiViewClassName: 'RNSVGCircle'
-});
+}));

--- a/elements/Circle.js
+++ b/elements/Circle.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import createReactNativeComponentClass from 'react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js';
+import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
 import Shape from './Shape';
 import {CircleAttributes} from '../lib/attributes';
 import {pathProps, numberProp} from '../lib/props';

--- a/elements/ClipPath.js
+++ b/elements/ClipPath.js
@@ -14,7 +14,7 @@ export default class extends Component{
     }
 }
 
-const RNSVGClipPath = createReactNativeComponentClass({
+const RNSVGClipPath = createReactNativeComponentClass('RNSVGClipPath', () => ({
     validAttributes: ClipPathAttributes,
     uiViewClassName: 'RNSVGClipPath'
-});
+}));

--- a/elements/ClipPath.js
+++ b/elements/ClipPath.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import createReactNativeComponentClass from 'react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js';
+import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
 import {ClipPathAttributes} from '../lib/attributes';
 
 export default class extends Component{

--- a/elements/Defs.js
+++ b/elements/Defs.js
@@ -9,7 +9,7 @@ export default class extends Component {
     }
 }
 
-const RNSVGDefs = createReactNativeComponentClass({
+const RNSVGDefs = createReactNativeComponentClass('RNSVGDefs', () => ({
     validAttributes: {},
     uiViewClassName: 'RNSVGDefs'
-});
+}));

--- a/elements/Defs.js
+++ b/elements/Defs.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import createReactNativeComponentClass from 'react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js';
+import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
 
 export default class extends Component {
     static displayName = 'Defs';

--- a/elements/Ellipse.js
+++ b/elements/Ellipse.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import createReactNativeComponentClass from 'react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js';
+import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
 import Shape from './Shape';
 import {pathProps, numberProp} from '../lib/props';
 import {EllipseAttributes} from '../lib/attributes';

--- a/elements/Ellipse.js
+++ b/elements/Ellipse.js
@@ -41,7 +41,7 @@ export default class extends Shape{
     }
 }
 
-const RNSVGEllipse = createReactNativeComponentClass({
+const RNSVGEllipse = createReactNativeComponentClass('RNSVGEllipse', () => ({
     validAttributes: EllipseAttributes,
     uiViewClassName: 'RNSVGEllipse'
-});
+}));

--- a/elements/G.js
+++ b/elements/G.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import createReactNativeComponentClass from 'react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js';
+import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
 import Shape from './Shape';
 import {pathProps} from '../lib/props';
 import {GroupAttributes} from '../lib/attributes';

--- a/elements/G.js
+++ b/elements/G.js
@@ -26,7 +26,7 @@ export default class extends Shape{
     }
 }
 
-const RNSVGGroup = createReactNativeComponentClass({
+const RNSVGGroup = createReactNativeComponentClass('RNSVGGroup', () => ({
     validAttributes: GroupAttributes,
     uiViewClassName: 'RNSVGGroup'
-});
+}));

--- a/elements/Image.js
+++ b/elements/Image.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Image } from 'react-native';
-import createReactNativeComponentClass from 'react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js';
+import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
 import {ImageAttributes} from '../lib/attributes';
 import {numberProp, touchableProps, responderProps} from '../lib/props';
 import Shape from './Shape';

--- a/elements/Image.js
+++ b/elements/Image.js
@@ -56,7 +56,7 @@ export default class extends Shape {
     }
 }
 
-const RNSVGImage = createReactNativeComponentClass({
+const RNSVGImage = createReactNativeComponentClass('RNSVGImage', () => ({
     validAttributes: ImageAttributes,
     uiViewClassName: 'RNSVGImage'
-});
+}));

--- a/elements/Line.js
+++ b/elements/Line.js
@@ -40,7 +40,7 @@ export default class extends Shape {
     }
 }
 
-const RNSVGLine = createReactNativeComponentClass({
+const RNSVGLine = createReactNativeComponentClass('RNSVGLine', () => ({
     validAttributes: LineAttributes,
     uiViewClassName: 'RNSVGLine'
-});
+}));

--- a/elements/Line.js
+++ b/elements/Line.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import createReactNativeComponentClass from 'react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js';
+import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
 import {LineAttributes} from '../lib/attributes';
 import Shape from './Shape';
 import {pathProps, numberProp} from '../lib/props';

--- a/elements/LinearGradient.js
+++ b/elements/LinearGradient.js
@@ -36,7 +36,10 @@ export default class extends Component{
     }
 }
 
-const RNSVGLinearGradient = createReactNativeComponentClass({
-    validAttributes: LinearGradientAttributes,
-    uiViewClassName: 'RNSVGLinearGradient'
-});
+const RNSVGLinearGradient = createReactNativeComponentClass(
+    'RNSVGLinearGradient',
+    () => ({
+        validAttributes: LinearGradientAttributes,
+        uiViewClassName: 'RNSVGLinearGradient'
+    })
+);

--- a/elements/LinearGradient.js
+++ b/elements/LinearGradient.js
@@ -2,7 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {numberProp} from '../lib/props';
 import extractGradient from '../lib/extract/extractGradient';
-import createReactNativeComponentClass from 'react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js';
+import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
 import {LinearGradientAttributes} from '../lib/attributes';
 
 export default class extends Component{

--- a/elements/Path.js
+++ b/elements/Path.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import createReactNativeComponentClass from 'react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js';
+import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
 import {PathAttributes} from '../lib/attributes';
 import Shape from './Shape';
 import {pathProps} from '../lib/props';

--- a/elements/Path.js
+++ b/elements/Path.js
@@ -31,7 +31,7 @@ export default class extends Shape {
     }
 }
 
-const RNSVGPath = createReactNativeComponentClass({
+const RNSVGPath = createReactNativeComponentClass('RNSVGPath', () => ({
     validAttributes: PathAttributes,
     uiViewClassName: 'RNSVGPath'
-});
+}));

--- a/elements/RadialGradient.js
+++ b/elements/RadialGradient.js
@@ -42,7 +42,10 @@ export default class extends Component{
     }
 }
 
-const RNSVGRadialGradient = createReactNativeComponentClass({
-    validAttributes: RadialGradientAttributes,
-    uiViewClassName: 'RNSVGRadialGradient'
-});
+const RNSVGRadialGradient = createReactNativeComponentClass(
+    'RNSVGRadialGradient',
+    () => ({
+        validAttributes: RadialGradientAttributes,
+        uiViewClassName: 'RNSVGRadialGradient'
+    })
+);

--- a/elements/RadialGradient.js
+++ b/elements/RadialGradient.js
@@ -2,7 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {numberProp} from '../lib/props';
 import extractGradient from '../lib/extract/extractGradient';
-import createReactNativeComponentClass from 'react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js';
+import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
 import {RadialGradientAttributes} from '../lib/attributes';
 
 export default class extends Component{

--- a/elements/Rect.js
+++ b/elements/Rect.js
@@ -52,7 +52,7 @@ export default class extends Shape {
     }
 }
 
-const RNSVGRect = createReactNativeComponentClass({
+const RNSVGRect = createReactNativeComponentClass('RNSVGRect', () => ({
     validAttributes: RectAttributes,
     uiViewClassName: 'RNSVGRect'
-});
+}));

--- a/elements/Rect.js
+++ b/elements/Rect.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import './Path'; // must import Path first, don`t know why. without this will throw an `Super expression must either be null or a function, not undefined`
-import createReactNativeComponentClass from 'react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js';
+import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
 import {pathProps, numberProp} from '../lib/props';
 import {RectAttributes} from '../lib/attributes';
 import extractProps from '../lib/extract/extractProps';

--- a/elements/Symbol.js
+++ b/elements/Symbol.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import extractViewBox from '../lib/extract/extractViewBox';
-import createReactNativeComponentClass from 'react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js';
+import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
 import {SymbolAttributes} from '../lib/attributes';
 
 export default class extends Component{

--- a/elements/Symbol.js
+++ b/elements/Symbol.js
@@ -23,7 +23,7 @@ export default class extends Component{
     }
 }
 
-const RNSVGSymbol = createReactNativeComponentClass({
+const RNSVGSymbol = createReactNativeComponentClass('RNSVGSymbol', () => ({
     validAttributes: SymbolAttributes,
     uiViewClassName: 'RNSVGSymbol'
-});
+}));

--- a/elements/TSpan.js
+++ b/elements/TSpan.js
@@ -1,6 +1,6 @@
 import React  from 'react';
 import PropTypes from 'prop-types';
-import createReactNativeComponentClass from 'react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js';
+import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
 import extractText from '../lib/extract/extractText';
 import {numberProp, pathProps, fontProps} from '../lib/props';
 import {TSpanAttibutes} from '../lib/attributes';

--- a/elements/TSpan.js
+++ b/elements/TSpan.js
@@ -53,7 +53,7 @@ export default class extends Shape {
     }
 }
 
-const RNSVGTSpan = createReactNativeComponentClass({
+const RNSVGTSpan = createReactNativeComponentClass('RNSVGTSpan', () => ({
     validAttributes: TSpanAttibutes,
     uiViewClassName: 'RNSVGTSpan'
-});
+}));

--- a/elements/Text.js
+++ b/elements/Text.js
@@ -53,7 +53,7 @@ export default class extends Shape {
     }
 }
 
-const RNSVGText = createReactNativeComponentClass({
+const RNSVGText = createReactNativeComponentClass('RNSVGText', () => ({
     validAttributes: TextAttributes,
     uiViewClassName: 'RNSVGText'
-});
+}));

--- a/elements/Text.js
+++ b/elements/Text.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import createReactNativeComponentClass from 'react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js';
+import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
 import extractText from '../lib/extract/extractText';
 import {numberProp, pathProps, fontProps} from '../lib/props';
 import {TextAttributes} from '../lib/attributes';

--- a/elements/TextPath.js
+++ b/elements/TextPath.js
@@ -49,7 +49,7 @@ export default class extends Shape {
 
 }
 
-const RNSVGTextPath = createReactNativeComponentClass({
+const RNSVGTextPath = createReactNativeComponentClass('RNSVGTextPath', () => ({
     validAttributes: TextPathAttributes,
     uiViewClassName: 'RNSVGTextPath'
-});
+}));

--- a/elements/Use.js
+++ b/elements/Use.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import createReactNativeComponentClass from 'react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js';
+import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
 import extractProps from '../lib/extract/extractProps';
 import {pathProps, numberProp} from '../lib/props';
 import {UseAttributes} from '../lib/attributes';

--- a/elements/Use.js
+++ b/elements/Use.js
@@ -45,8 +45,7 @@ export default class extends Shape {
     }
 }
 
-const RNSVGUse = createReactNativeComponentClass({
+const RNSVGUse = createReactNativeComponentClass('RNSVGUse', () => ({
     validAttributes: UseAttributes,
     uiViewClassName: 'RNSVGUse'
-});
-
+}));

--- a/lib/createReactNativeComponentClass.js
+++ b/lib/createReactNativeComponentClass.js
@@ -1,0 +1,6 @@
+import createReactNativeComponentClass from 'react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js'
+
+export default (uiViewClassName, getViewConfig) =>
+  createReactNativeComponentClass.length >= 2
+    ? createReactNativeComponentClass(uiViewClassName, getViewConfig)
+    : createReactNativeComponentClass(getViewConfig)


### PR DESCRIPTION
While experimenting with the next release of react-native (0.50) I ran into the following error:

![screenshot_20171018-231143](https://user-images.githubusercontent.com/1381822/31743297-e80ecde8-b45a-11e7-87c5-e739b33eb568.png)

This error is caused by a recent change of an internal API found in this https://github.com/facebook/react-native/commit/e9780bdc0f00364359f39e5a76a3e43eadb93a4b commit.

My environment:
- react-native@0.50.0-rc.0
- react@16.0.0
- react-native-svg@5.4.2

This PR is just a proposal and needs to be updated with a conditional check on the react-native version in use. (only apply changes for react-native >= 0.50). Or even a new branch that has react-native@0.50 as `peerDependency`.

Any other suggestions?