### PR TITLE
Fix createReactNativeComponentClass for RN < 0.50

### DIFF
--- a/elements/TextPath.js
+++ b/elements/TextPath.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import createReactNativeComponentClass from 'react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js';
+import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
 import {TextPathAttributes} from '../lib/attributes';
 import extractText from '../lib/extract/extractText';
 import Shape from './Shape';

--- a/lib/createReactNativeComponentClass.js
+++ b/lib/createReactNativeComponentClass.js
@@ -3,4 +3,4 @@ import createReactNativeComponentClass from 'react-native/Libraries/Renderer/shi
 export default (uiViewClassName, getViewConfig) =>
   createReactNativeComponentClass.length >= 2
     ? createReactNativeComponentClass(uiViewClassName, getViewConfig)
-    : createReactNativeComponentClass(getViewConfig)
+    : createReactNativeComponentClass(getViewConfig())


### PR DESCRIPTION
Fix #498 

Sorry, the last PR #486 was merged with this bug.

A patch fix needs to be deployed cc @magicismight 

Current workaround: `npm install --save brunolemos/react-native-svg#rn-50-fix`