### PR TITLE
Update "color" dep to 2.x to fix RN minifier bug

### DIFF
--- a/lib/extract/extractBrush.js
+++ b/lib/extract/extractBrush.js
@@ -13,7 +13,7 @@ export default function (colorOrBrush) {
             return [1, matched[1]];
             //todo:
         } else { // solid color
-            let c = new Color(colorOrBrush).rgbaArray();
+            let c = Color(colorOrBrush).rgb().array();
             return [0, c[0] / 255, c[1] / 255, c[2] / 255, c[3]];
         }
     } catch (err) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "prop-types": "^15.5.8"
     },
     "dependencies": {
-        "color": "^0.11.1",
+        "color": "^2.0.1",
         "lodash": "^4.16.6",
         "github-download": "^0.5.0"
     },


### PR DESCRIPTION
There's a bug with the version of UglifyJS that RN/Metro uses which causes an error about "e.length" inside of "color" that was fixed in 2.x. One change to "color" is that `rgbaArray()` was removed and now the call is `rgb().array()`.