### PR TITLE
support rotations around defined points

### DIFF
--- a/lib/extract/extractTransform.js
+++ b/lib/extract/extractTransform.js
@@ -44,6 +44,8 @@ class TransformParser {
                         break;
                     case 'rotate':
                         retval.rotation = transLst[i + 1];
+                        retval.originX = (transLst.length > 2) ? transLst[i + 2] : retval.originX;
+                        retval.originY = (transLst.length > 3) ? transLst[i + 3] : retval.originY;
                         break;
                     case 'skewX':
                         retval.skewX = transLst[i + 1];


### PR DESCRIPTION
This PR uses optional `cx` and `cy` props from `rotate` to change the origin of a transformation when given. Should fix https://github.com/react-native-community/react-native-svg/issues/242