### PR TITLE
Handle color parsing when alpha = 1

### DIFF
--- a/lib/extract/extractBrush.js
+++ b/lib/extract/extractBrush.js
@@ -13,8 +13,8 @@ export default function (colorOrBrush) {
             return [1, matched[1]];
             //todo:
         } else { // solid color
-            let c = Color(colorOrBrush).rgb().array();
-            return [0, c[0] / 255, c[1] / 255, c[2] / 255, c[3]];
+            let [r, g, b, a = 1] = Color(colorOrBrush).rgb().array();
+            return [0, r / 255, g / 255, b / 255, a];
         }
     } catch (err) {
         console.warn(`"${colorOrBrush}" is not a valid color or brush`);

--- a/lib/extract/extractGradient.js
+++ b/lib/extract/extractGradient.js
@@ -36,11 +36,11 @@ export default function(props) {
     const gradient = [];
 
     sorted.forEach(({stop}) => {
-        let channels = stop.rgbaArray();
-        gradient.push(channels[0] / 255);
-        gradient.push(channels[1] / 255);
-        gradient.push(channels[2] / 255);
-        gradient.push(channels[3]);
+        let [r, g, b, a = 1] = stop.rgb().array();
+        gradient.push(r / 255);
+        gradient.push(g / 255);
+        gradient.push(b / 255);
+        gradient.push(a);
     });
 
     gradient.push(...sorted.map(({offset}) => +offset));


### PR DESCRIPTION
The `color` library doesn't include alpha when accessing `color.rgb().array()` when the alpha value is 1. Since we always use the alpha value, make it default to 1 when parsing a color.

This fixes a redbox on Android about expecting a double, but receiving null.