### PR TITLE
Fixes Android Release images not rendering (Issue #129)

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RenderableShadowNode.java
+++ b/android/src/main/java/com/horcrux/svg/RenderableShadowNode.java
@@ -269,7 +269,7 @@ abstract public class RenderableShadowNode extends VirtualNode {
         if (colorType == 0) {
             // solid color
             paint.setARGB(
-                    (int) (colors.size() > 4 ? colors.getDouble(4) * opacity * 255 : opacity * 255),
+                    (int) (colors.size() > 4 && !colors.isNull(4) ? colors.getDouble(4) * opacity * 255 : opacity * 255),
                     (int) (colors.getDouble(1) * 255),
                     (int) (colors.getDouble(2) * 255),
                     (int) (colors.getDouble(3) * 255));

--- a/android/src/main/java/com/horcrux/svg/RenderableShadowNode.java
+++ b/android/src/main/java/com/horcrux/svg/RenderableShadowNode.java
@@ -269,7 +269,7 @@ abstract public class RenderableShadowNode extends VirtualNode {
         if (colorType == 0) {
             // solid color
             paint.setARGB(
-                    (int) (colors.size() > 4 && !colors.isNull(4) ? colors.getDouble(4) * opacity * 255 : opacity * 255),
+                    (int) (colors.size() > 4 ? colors.getDouble(4) * opacity * 255 : opacity * 255),
                     (int) (colors.getDouble(1) * 255),
                     (int) (colors.getDouble(2) * 255),
                     (int) (colors.getDouble(3) * 255));


### PR DESCRIPTION
## Fixes Android Release images not rendering (Issue #129)

Issue caused by 2 things:

- Image resources were not properly getting the path due to missing scheme (if required via require('./images/img.png'))
- markUpdated() was not causing a re-render thus image was not updating if it was a resource id after fetching. This is been changed to directly call bitmapTryRender, however, this may not be the best approach to this issue.

Minor note: After making this change, RenderableShadowNode would get a null for images. I put a null check for the alpha parameter to suppress this.