### PR TITLE
[FIX] colors array contains null when alpha = 1

### DIFF
--- a/lib/extract/extractBrush.js
+++ b/lib/extract/extractBrush.js
@@ -16,6 +16,9 @@ export default function (colorOrBrush) {
             let c = Color(colorOrBrush).unitArray();
             // Color returns an array of length 3 when alpha = 1
             // if use c[3], this array would be of length 5 and contains null value
+            if (c.length === 3) {
+                c.push(1);
+            }
             return [0, ...c];
         }
     } catch (err) {

--- a/lib/extract/extractBrush.js
+++ b/lib/extract/extractBrush.js
@@ -13,8 +13,10 @@ export default function (colorOrBrush) {
             return [1, matched[1]];
             //todo:
         } else { // solid color
-            let c = Color(colorOrBrush).rgb().array();
-            return [0, c[0] / 255, c[1] / 255, c[2] / 255, c[3]];
+            let c = Color(colorOrBrush).unitArray();
+            // Color returns an array of length 3 when alpha = 1
+            // if use c[3], this array would be of length 5 and contains null value
+            return [0, ...c];
         }
     } catch (err) {
         console.warn(`"${colorOrBrush}" is not a valid color or brush`);


### PR DESCRIPTION
the current way to get solid color array may lead to an error that native module receives an array which contains null when alpha = 1.