### PR TITLE
Implement getAlignmentBaseline and getBaselineShift in ios.

### DIFF
--- a/android/src/main/java/com/horcrux/svg/TSpanShadowNode.java
+++ b/android/src/main/java/com/horcrux/svg/TSpanShadowNode.java
@@ -499,10 +499,10 @@ class TSpanShadowNode extends TextShadowNode {
             Neither 'text-before-edge' nor 'text-after-edge' should be used with the vertical-align property.
         */
         final Paint.FontMetrics fm = paint.getFontMetrics();
-        final double top = -fm.top;
-        final double bottom = fm.bottom;
-        final double ascenderHeight = -fm.ascent;
         final double descenderDepth = fm.descent;
+        final double bottom = descenderDepth + fm.leading;
+        final double ascenderHeight = -fm.ascent + fm.leading;
+        final double top = -fm.top;
         final double totalHeight = top + bottom;
         double baselineShift = 0;
         String baselineShiftString = getBaselineShift();
@@ -593,6 +593,7 @@ class TSpanShadowNode extends TextShadowNode {
                     baselineShift = top;
                     break;
             }
+        }
         /*
         2.2.2. Alignment Shift: baseline-shift longhand
 
@@ -621,52 +622,51 @@ class TSpanShadowNode extends TextShadowNode {
 
         https://www.w3.org/TR/css-inline-3/#propdef-baseline-shift
         */
-            if (baselineShiftString != null) {
-                switch (baseline) {
-                    case top:
-                    case bottom:
-                        break;
+        if (baselineShiftString != null && !baselineShiftString.isEmpty()) {
+            switch (baseline) {
+                case top:
+                case bottom:
+                    break;
 
-                    default:
-                        switch (baselineShiftString) {
-                            case "sub":
-                                // TODO
-                                if (fontData != null && fontData.hasKey("tables") && fontData.hasKey("unitsPerEm")) {
-                                    int unitsPerEm = fontData.getInt("unitsPerEm");
-                                    ReadableMap tables = fontData.getMap("tables");
-                                    if (tables.hasKey("os2")) {
-                                        ReadableMap os2 = tables.getMap("os2");
-                                        if (os2.hasKey("ySubscriptYOffset")) {
-                                            double subOffset = os2.getDouble("ySubscriptYOffset");
-                                            baselineShift += fontSize * subOffset / unitsPerEm;
-                                        }
+                default:
+                    switch (baselineShiftString) {
+                        case "sub":
+                            // TODO
+                            if (fontData != null && fontData.hasKey("tables") && fontData.hasKey("unitsPerEm")) {
+                                int unitsPerEm = fontData.getInt("unitsPerEm");
+                                ReadableMap tables = fontData.getMap("tables");
+                                if (tables.hasKey("os2")) {
+                                    ReadableMap os2 = tables.getMap("os2");
+                                    if (os2.hasKey("ySubscriptYOffset")) {
+                                        double subOffset = os2.getDouble("ySubscriptYOffset");
+                                        baselineShift += mScale * fontSize * subOffset / unitsPerEm;
                                     }
                                 }
-                                break;
+                            }
+                            break;
 
-                            case "super":
-                                // TODO
-                                if (fontData != null && fontData.hasKey("tables") && fontData.hasKey("unitsPerEm")) {
-                                    int unitsPerEm = fontData.getInt("unitsPerEm");
-                                    ReadableMap tables = fontData.getMap("tables");
-                                    if (tables.hasKey("os2")) {
-                                        ReadableMap os2 = tables.getMap("os2");
-                                        if (os2.hasKey("ySuperscriptYOffset")) {
-                                            double superOffset = os2.getDouble("ySuperscriptYOffset");
-                                            baselineShift -= fontSize * superOffset / unitsPerEm;
-                                        }
+                        case "super":
+                            // TODO
+                            if (fontData != null && fontData.hasKey("tables") && fontData.hasKey("unitsPerEm")) {
+                                int unitsPerEm = fontData.getInt("unitsPerEm");
+                                ReadableMap tables = fontData.getMap("tables");
+                                if (tables.hasKey("os2")) {
+                                    ReadableMap os2 = tables.getMap("os2");
+                                    if (os2.hasKey("ySuperscriptYOffset")) {
+                                        double superOffset = os2.getDouble("ySuperscriptYOffset");
+                                        baselineShift -= mScale * fontSize * superOffset / unitsPerEm;
                                     }
                                 }
-                                break;
+                            }
+                            break;
 
-                            case "baseline":
-                                break;
+                        case "baseline":
+                            break;
 
-                            default:
-                                baselineShift -= PropHelper.fromRelative(baselineShiftString, fontSize, 0, mScale, fontSize);
-                        }
-                        break;
-                }
+                        default:
+                            baselineShift -= PropHelper.fromRelative(baselineShiftString, mScale * fontSize, 0, mScale, fontSize);
+                    }
+                    break;
             }
         }
 

--- a/ios/Elements/RNSVGGroup.m
+++ b/ios/Elements/RNSVGGroup.m
@@ -13,6 +13,16 @@
     GlyphContext *_glyphContext;
 }
 
+- (void)setFont:(NSDictionary*)font
+{
+    if (font == _font) {
+        return;
+    }
+
+    [self invalidate];
+    _font = font;
+}
+
 - (void)renderLayerTo:(CGContextRef)context
 {
     [self clip:context];

--- a/ios/Elements/RNSVGGroup.m
+++ b/ios/Elements/RNSVGGroup.m
@@ -62,7 +62,7 @@
 
 - (void)pushGlyphContext
 {
-    [[[self getTextRoot] getGlyphContext] pushContextWithRNSVGGroup:self font:self.font];
+    [[[self getTextRoot] getGlyphContext] pushContext:self font:self.font];
 }
 
 - (void)popGlyphContext

--- a/ios/Text/GlyphContext.h
+++ b/ios/Text/GlyphContext.h
@@ -34,8 +34,7 @@
 
 - (void)popContext;
 
-- (void)pushContextwithRNSVGText:(RNSVGText *)node
-                           reset:(bool)reset
+- (void)pushContext:(RNSVGText *)node
                             font:(NSDictionary *)font
                                x:(NSArray*)x
                                y:(NSArray*)y
@@ -43,7 +42,7 @@
                           deltaY:(NSArray*)deltaY
                           rotate:(NSArray*)rotate;
 
-- (void)pushContextWithRNSVGGroup:(RNSVGGroup*)node
+- (void)pushContext:(RNSVGGroup*)node
                              font:(NSDictionary *)font;
 
 

--- a/ios/Text/RNSVGTSpan.m
+++ b/ios/Text/RNSVGTSpan.m
@@ -12,6 +12,8 @@
 #import "RNSVGTextPath.h"
 #import "FontData.h"
 
+NSCharacterSet *separators = nil;
+
 @implementation RNSVGTSpan
 {
     CGFloat startOffset;
@@ -21,6 +23,17 @@
     RNSVGTextPath * textPath;
     RNSVGPath * textPathPath;
     bool isClosed;
+}
+
+- (id)init
+{
+    self = [super init];
+
+    if (separators == nil) {
+        separators = [NSCharacterSet whitespaceCharacterSet];
+    }
+
+    return self;
 }
 
 - (void)setContent:(NSString *)content
@@ -517,8 +530,8 @@
         double totalHeight = top + bottom;
         double baselineShift = 0;
         // TODO, alignmentBaseline and baselineShift are always nil for some reason?
-        NSString *baselineShiftString = [self baselineShift];
-        enum AlignmentBaseline baseline = AlignmentBaselineFromString([self alignmentBaseline]);
+        NSString *baselineShiftString = [self getBaselineShift];
+        enum AlignmentBaseline baseline = AlignmentBaselineFromString([self getAlignmentBaseline]);
         if (baseline != AlignmentBaselineBaseline) {
             // TODO alignment-baseline, test / verify behavior
             // TODO get per glyph baselines from font baseline table, for high-precision alignment
@@ -709,7 +722,8 @@
                 kerning = kerned - charWidth;
             }
 
-            bool isWordSeparator = false;
+            char currentChar = [str characterAtIndex:i];
+            bool isWordSeparator = [separators characterIsMember:currentChar];
             double wordSpace = isWordSeparator ? wordSpacing : 0;
             double spacing = wordSpace + letterSpacing;
             double advance = charWidth + spacing;

--- a/ios/Text/RNSVGTSpan.m
+++ b/ios/Text/RNSVGTSpan.m
@@ -615,72 +615,72 @@ NSCharacterSet *separators = nil;
                     baselineShift = top;
                     break;
             }
-            /*
-             2.2.2. Alignment Shift: baseline-shift longhand
+        }
+        /*
+         2.2.2. Alignment Shift: baseline-shift longhand
 
-             This property specifies by how much the box is shifted up from its alignment point.
-             It does not apply when alignment-baseline is top or bottom.
+         This property specifies by how much the box is shifted up from its alignment point.
+         It does not apply when alignment-baseline is top or bottom.
 
-             Authors should use the vertical-align shorthand instead of this property.
+         Authors should use the vertical-align shorthand instead of this property.
 
-             Values have the following meanings:
+         Values have the following meanings:
 
-             <length>
-             Raise (positive value) or lower (negative value) by the specified length.
-             <percentage>
-             Raise (positive value) or lower (negative value) by the specified percentage of the line-height.
-             TODO sub
-             Lower by the offset appropriate for subscripts of the parent’s box.
-             (The UA should use the parent’s font data to find this offset whenever possible.)
-             TODO super
-             Raise by the offset appropriate for superscripts of the parent’s box.
-             (The UA should use the parent’s font data to find this offset whenever possible.)
+         <length>
+         Raise (positive value) or lower (negative value) by the specified length.
+         <percentage>
+         Raise (positive value) or lower (negative value) by the specified percentage of the line-height.
+         TODO sub
+         Lower by the offset appropriate for subscripts of the parent’s box.
+         (The UA should use the parent’s font data to find this offset whenever possible.)
+         TODO super
+         Raise by the offset appropriate for superscripts of the parent’s box.
+         (The UA should use the parent’s font data to find this offset whenever possible.)
 
-             User agents may additionally support the keyword baseline as computing to 0
-             if is necessary for them to support legacy SVG content.
-             Issue: We would prefer to remove this,
-             and are looking for feedback from SVG user agents as to whether it’s necessary.
+         User agents may additionally support the keyword baseline as computing to 0
+         if is necessary for them to support legacy SVG content.
+         Issue: We would prefer to remove this,
+         and are looking for feedback from SVG user agents as to whether it’s necessary.
 
-             https://www.w3.org/TR/css-inline-3/#propdef-baseline-shift
-             */
-            if (baselineShiftString != nil && fontData != nil) {
-                switch (baseline) {
-                    case AlignmentBaselineTop:
-                    case AlignmentBaselineBottom:
-                        break;
+         https://www.w3.org/TR/css-inline-3/#propdef-baseline-shift
+         */
+        if (baselineShiftString != nil && ![baselineShiftString isEqualToString:@""]) {
+            switch (baseline) {
+                case AlignmentBaselineTop:
+                case AlignmentBaselineBottom:
+                    break;
 
-                    default:
-                        if ([baselineShiftString isEqualToString:@"sub"]) {
-                            // TODO
-                            NSDictionary* tables = [fontData objectForKey:@"tables"];
-                            NSNumber* unitsPerEm = [fontData objectForKey:@"unitsPerEm"];
-                            NSDictionary* os2 = [tables objectForKey:@"os2"];
-                            NSNumber* ySubscriptYOffset = [os2 objectForKey:@"ySubscriptYOffset"];
-                            if (ySubscriptYOffset) {
-                                double subOffset = [ySubscriptYOffset doubleValue];
-                                baselineShift += fontSize * subOffset / [unitsPerEm doubleValue];
-                            }
-                        } else if ([baselineShiftString isEqualToString:@"super"]) {
-                            // TODO
-                            NSDictionary* tables = [fontData objectForKey:@"tables"];
-                            NSNumber* unitsPerEm = [fontData objectForKey:@"unitsPerEm"];
-                            NSDictionary* os2 = [tables objectForKey:@"os2"];
-                            NSNumber* ySuperscriptYOffset = [os2 objectForKey:@"ySuperscriptYOffset"];
-                            if (ySuperscriptYOffset) {
-                                double superOffset = [ySuperscriptYOffset doubleValue];
-                                baselineShift -= fontSize * superOffset / [unitsPerEm doubleValue];
-                            }
-                        } else if ([baselineShiftString isEqualToString:@"baseline"]) {
-                        } else {
-                            baselineShift -= [PropHelper fromRelativeWithNSString:baselineShiftString
-                                                                         relative:fontSize
-                                                                           offset:0
-                                                                            scale:1
-                                                                         fontSize:fontSize];
-
+                default:
+                    if (fontData != nil && [baselineShiftString isEqualToString:@"sub"]) {
+                        // TODO
+                        NSDictionary* tables = [fontData objectForKey:@"tables"];
+                        NSNumber* unitsPerEm = [fontData objectForKey:@"unitsPerEm"];
+                        NSDictionary* os2 = [tables objectForKey:@"os2"];
+                        NSNumber* ySubscriptYOffset = [os2 objectForKey:@"ySubscriptYOffset"];
+                        if (ySubscriptYOffset) {
+                            double subOffset = [ySubscriptYOffset doubleValue];
+                            baselineShift += fontSize * subOffset / [unitsPerEm doubleValue];
                         }
-                        break;
-                }
+                    } else if (fontData != nil && [baselineShiftString isEqualToString:@"super"]) {
+                        // TODO
+                        NSDictionary* tables = [fontData objectForKey:@"tables"];
+                        NSNumber* unitsPerEm = [fontData objectForKey:@"unitsPerEm"];
+                        NSDictionary* os2 = [tables objectForKey:@"os2"];
+                        NSNumber* ySuperscriptYOffset = [os2 objectForKey:@"ySuperscriptYOffset"];
+                        if (ySuperscriptYOffset) {
+                            double superOffset = [ySuperscriptYOffset doubleValue];
+                            baselineShift -= fontSize * superOffset / [unitsPerEm doubleValue];
+                        }
+                    } else if ([baselineShiftString isEqualToString:@"baseline"]) {
+                    } else {
+                        baselineShift -= [PropHelper fromRelativeWithNSString:baselineShiftString
+                                                                     relative:fontSize
+                                                                       offset:0
+                                                                        scale:1
+                                                                     fontSize:fontSize];
+
+                    }
+                    break;
             }
         }
         int i = -1;

--- a/ios/Text/RNSVGText.h
+++ b/ios/Text/RNSVGText.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "RNSVGGroup.h"
 #import "RNSVGTextAnchor.h"
+#import "AlignmentBaseline.h"
 
 @interface RNSVGText : RNSVGGroup
 
@@ -25,5 +26,7 @@
 - (void)releaseCachedPath;
 - (CGPathRef)getGroupPath:(CGContextRef)context;
 - (CTFontRef)getFontFromContext;
+- (NSString*) getAlignmentBaseline;
+- (NSString*) getBaselineShift;
 
 @end

--- a/ios/Text/RNSVGText.m
+++ b/ios/Text/RNSVGText.m
@@ -91,6 +91,54 @@
     return _textRoot;
 }
 
+- (NSString*) getAlignmentBaseline
+{
+    if (self.alignmentBaseline != nil) {
+        return self.alignmentBaseline;
+    }
+    UIView* parent = [self superview];
+    while (parent != nil) {
+        if ([parent isKindOfClass:[RNSVGText class]]) {
+            RNSVGText* node = (RNSVGText*)parent;
+            NSString* baseline = node.alignmentBaseline;
+            if (baseline != nil) {
+                self.alignmentBaseline = baseline;
+                return baseline;
+            }
+        }
+        parent = [parent superview];
+    }
+    if (self.alignmentBaseline == nil) {
+        self.alignmentBaseline = AlignmentBaselineStrings[0];
+    }
+    return self.alignmentBaseline;
+}
+
+- (NSString*) getBaselineShift
+{
+    if (self.baselineShift != nil) {
+        return self.baselineShift;
+    }
+    if (self.baselineShift == nil) {
+        UIView* parent = [self superview];
+        while (parent != nil) {
+            if ([parent isKindOfClass:[RNSVGText class]]) {
+                RNSVGText* node = (RNSVGText*)parent;
+                NSString* baselineShift = node.baselineShift;
+                if (baselineShift != nil) {
+                    self.baselineShift = baselineShift;
+                    return baselineShift;
+                }
+            }
+            parent = [parent superview];
+        }
+    }
+    if (self.baselineShift == nil) {
+        self.baselineShift = @"";
+    }
+    return self.baselineShift;
+}
+
 - (GlyphContext *)getGlyphContext
 {
     return _glyphContext;
@@ -98,8 +146,7 @@
 
 - (void)pushGlyphContext
 {
-    [[[self getTextRoot] getGlyphContext] pushContextwithRNSVGText:self
-                                                             reset:false
+    [[[self getTextRoot] getGlyphContext] pushContext:self
                                                               font:self.font
                                                                  x:self.positionX
                                                                  y:self.positionY

--- a/ios/ViewManagers/RNSVGGroupManager.m
+++ b/ios/ViewManagers/RNSVGGroupManager.m
@@ -19,4 +19,6 @@ RCT_EXPORT_MODULE()
   return [RNSVGGroup new];
 }
 
+RCT_EXPORT_VIEW_PROPERTY(font, NSDictionary)
+
 @end

--- a/ios/ViewManagers/RNSVGRenderableManager.m
+++ b/ios/ViewManagers/RNSVGRenderableManager.m
@@ -32,6 +32,5 @@ RCT_EXPORT_VIEW_PROPERTY(strokeDasharray, NSArray<NSString *>)
 RCT_EXPORT_VIEW_PROPERTY(strokeDashoffset, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(strokeMiterlimit, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(propList, NSArray<NSString *>)
-RCT_EXPORT_VIEW_PROPERTY(font, NSDictionary)
 
 @end

--- a/lib/extract/extractProps.js
+++ b/lib/extract/extractProps.js
@@ -1,6 +1,6 @@
 import extractFill from './extractFill';
 import extractStroke from './extractStroke';
-import extractTransform, {props2transform, tp} from './extractTransform';
+import extractTransform, {props2transform} from './extractTransform';
 import extractClipPath from './extractClipPath';
 import extractResponder from './extractResponder';
 import extractOpacity from './extractOpacity';
@@ -27,21 +27,6 @@ export default function(props, ref) {
     extractedProps.matrix = extractTransform(props);
 
     Object.assign(extractedProps, props2transform(props));
-    let transform = props.transform;
-    if (transform) {
-        if (typeof transform === 'string') {
-            const transformParsed = tp.parse(transform);
-            if (transformParsed.matrix) {
-                // TODO: Extract scaling values for coordinate system
-                // Especially scaleY for calculating scaling of fontSize
-            } else {
-                let trans = props2transform(transformParsed);
-                if (typeof trans === 'object') {
-                    Object.assign(extractedProps, trans);
-                }
-            }
-        }
-    }
 
     Object.assign(extractedProps, extractResponder(props, ref));
 

--- a/lib/extract/extractTransform.js
+++ b/lib/extract/extractTransform.js
@@ -1,6 +1,7 @@
 import Matrix2D from '../Matrix2D';
 import _ from 'lodash';
 let pooledMatrix = new Matrix2D();
+import peg from 'pegjs';
 
 function transformToMatrix(props, transform) {
     pooledMatrix.reset();
@@ -13,73 +14,172 @@ function transformToMatrix(props, transform) {
     return pooledMatrix.toArray();
 }
 
-const SPLIT_REGEX = /[\s*()|,]/;
+const transformParser = peg.generate(`
+{
+    const deg2rad = Math.PI / 180;
 
-class TransformParser {
+    /*
+     ╔═        ═╗   ╔═        ═╗   ╔═     ═╗
+     ║ al cl el ║   ║ ar cr er ║   ║ a c e ║
+     ║ bl dl fl ║ * ║ br dr fr ║ = ║ b d f ║
+     ║ 0  0  1  ║   ║ 0  0  1  ║   ║ 0 0 1 ║
+     ╚═        ═╝   ╚═        ═╝   ╚═     ═╝
+    */
+    function multiply_matrices(l, r) {
+        const [al, cl, el, bl, dl, fl] = l;
+        const [ar, cr, er, br, dr, fr] = r;
 
-    parse(transform) {
-        if (transform) {
-            const retval = {};
-            let transLst = _.filter(
-              transform.split(SPLIT_REGEX),
-              (ele) => {
-                return ele !== '';
-              }
-            );
-            for (let i = 0; i < transLst.length; i++) {
-                let trans = transLst[i];
-                switch (trans) {
-                    case 'matrix':
-                        if (i + 7 <= transLst.length) {
-                            retval.matrix = _.map((transLst.slice(i + 1,i + 7)), parseFloat);
-                        }
-                        break;
-                    case 'translate':
-                        retval.translateX = transLst[i + 1];
-                        retval.translateY = (transLst.length === 3) ? transLst[i + 2] : 0;
-                        break;
-                    case 'scale':
-                        retval.scaleX = transLst[i + 1];
-                        retval.scaleY = (transLst.length === 3) ? transLst[i + 2] : retval.scaleX;
-                        break;
-                    case 'rotate':
-                        retval.rotation = transLst[i + 1];
-                        retval.originX = (transLst.length > 2) ? transLst[i + 2] : retval.originX;
-                        retval.originY = (transLst.length > 3) ? transLst[i + 3] : retval.originY;
-                        break;
-                    case 'skewX':
-                        retval.skewX = transLst[i + 1];
-                        break;
-                    case 'skewY':
-                        retval.skewY = transLst[i + 1];
-                        break;
-                    default:
-                        break;
-                }
-            }
-            return retval;
-        }
+        const a = al * ar + cl * br;
+        const c = al * cr + cl * dr;
+        const e = al * er + cl * fr + el;
+        const b = bl * ar + dl * br;
+        const d = bl * cr + dl * dr;
+        const f = bl * er + dl * fr + fl;
+
+        return [a, c, e, b, d, f];
     }
 }
 
-export const tp = new TransformParser();
+transformList
+    = wsp* ts:transforms? wsp* { return ts; }
 
+transforms
+    = t:transform commaWsp+ ts:transforms
+    {
+        return multiply_matrices(t, ts);
+    }
+    / t:transform
+
+transform
+    = matrix
+    / translate
+    / scale
+    / rotate
+    / skewX
+    / skewY
+
+matrix
+    = "matrix" wsp* "(" wsp*
+        a:number commaWsp
+        b:number commaWsp
+        c:number commaWsp
+        d:number commaWsp
+        e:number commaWsp
+        f:number wsp* ")"
+    {
+        return [
+            a, c, e,
+            b, d, f
+        ];
+    }
+
+translate
+    = "translate" wsp* "(" wsp* tx:number ty:commaWspNumber? wsp* ")"
+    {
+        return [
+            1, 0, tx,
+            0, 1, ty || 0
+        ];
+    }
+
+scale
+    = "scale" wsp* "(" wsp* sx:number sy:commaWspNumber? wsp* ")"
+    {
+        return [
+            sx, 0,                     0,
+            0,  sy === null ? sx : sy, 0
+        ];
+    }
+
+rotate
+    = "rotate" wsp* "(" wsp* angle:number c:commaWspTwoNumbers? wsp* ")"
+    {
+        const cos = Math.cos(deg2rad * angle);
+        const sin = Math.sin(deg2rad * angle);
+        if (c !== null) {
+            const [x, y] = c;
+            return [
+                cos, -sin, cos * -x + -sin * -y + x,
+                sin,  cos, sin * -x +  cos * -y + y
+            ];
+        }
+        return [
+            cos, -sin, 0,
+            sin,  cos, 0
+        ];
+    }
+
+skewX
+    = "skewX" wsp* "(" wsp* angle:number wsp* ")"
+    {
+        return [
+            1, Math.tan(deg2rad * angle), 0,
+            0, 1,                         0
+        ];
+    }
+
+skewY
+    = "skewY" wsp* "(" wsp* angle:number wsp* ")"
+    {
+        return [
+            1,                         0, 0,
+            Math.tan(deg2rad * angle), 1, 0
+        ];
+    }
+
+number
+    = f:(sign? floatingPointConstant) { return parseFloat(f.join("")); }
+    / i:(sign? integerConstant) { return parseInt(i.join("")); }
+
+commaWspNumber
+    = commaWsp n:number { return n; }
+
+commaWspTwoNumbers
+    = commaWsp n1:number commaWsp n2:number { return [n1, n2]; }
+
+commaWsp
+    = (wsp+ comma? wsp*) / (comma wsp*)
+
+comma
+    = ","
+
+integerConstant
+    = ds:digitSequence { return ds.join(""); }
+
+floatingPointConstant
+    = fractionalConstant exponent?
+    / digitSequence exponent
+
+    fractionalConstant "fractionalConstant"
+    = d1:digitSequence? "." d2:digitSequence { return [d1 ? d1.join("") : null, ".", d2.join("")].join(""); }
+    / d:digitSequence "." { return d.join(""); }
+
+exponent
+    =  [eE] sign? digitSequence
+
+sign
+    = [+-]
+
+digitSequence
+    = digit+
+
+digit
+    = [0-9]
+
+wsp
+    = [\\u0020\\u0009\\u000D\\u000A]
+`);
 
 function appendTransform(transform) {
     if (transform) {
         if (typeof transform === 'string') {
-            const transformParsed = tp.parse(transform);
-            if (transformParsed.matrix) {
-                pooledMatrix.append(...transformParsed.matrix);
+            try {
+                const [a, c, e, b, d, f] = transformParser.parse(transform);
+                pooledMatrix.append(...[a, b, c, d, e, f]);
+            } catch (e) {
+                console.error(e);
             }
-            else {
-                let trans = props2transform(transformParsed);
-                if (typeof trans !== 'string') {
-                    transform = trans;
-                }
-            }
-        }
-        if (typeof transform !== 'string') {
+        } else {
             pooledMatrix
                 .appendTransform(
                     transform.x + transform.originX,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     ],
     "scripts": {
         "lint": "eslint ./",
-        "postinstall" : "node scripts/install.js"
+        "postinstall": "node scripts/install.js"
     },
     "peerDependencies": {
         "react-native": ">=0.50.0",
@@ -29,8 +29,9 @@
     },
     "dependencies": {
         "color": "^2.0.1",
+        "github-download": "^0.5.0",
         "lodash": "^4.16.6",
-        "github-download": "^0.5.0"
+        "pegjs": "^0.10.0"
     },
     "devDependencies": {
         "babel-eslint": "^6.1.2",


### PR DESCRIPTION
Add comments to glyphcontext and align with android.
Implement correct isWordSeparator predicate.
Cleanup GlyphContext j2objc remnants.