### PR TITLE
Fix crash when passing wrong type to percentage prop on iOS

### DIFF
--- a/ios/Utils/RNSVGPercentageConverter.m
+++ b/ios/Utils/RNSVGPercentageConverter.m
@@ -47,6 +47,9 @@ static NSRegularExpression* percentageRegExp;
 
 + (BOOL)isPercentage:(NSString *) string
 {
+    if (![string isKindOfClass:[NSString class]]) {
+      return NO;
+    }
     return [percentageRegExp firstMatchInString:string options:0 range:NSMakeRange(0, [string length])] != nil;
 }
 


### PR DESCRIPTION
`RNSVGPercentageConverter::isPercentage:` method can hard crash if somebody uses a type which doesn't respond to `length`, e.g. something like this: `[__NSArrayM length]: unrecognized selector sent to instance 0x61800924baf0`. Instead, just return `NO`, this is not a percentage.