### PR TITLE
Add exports for prop types, additional type fixes.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -205,8 +205,8 @@ export const Stop: React.ComponentClass<StopProps>;
 
 export interface SvgProps extends ReactNative.ViewProperties {
   opacity?: NumberProp,
-  width?: NumberProp,
-  height?: NumberProp,
+  width: NumberProp,
+  height: NumberProp,
   viewBox?: string,
   preserveAspectRatio?: string,
 }
@@ -215,12 +215,12 @@ export interface SvgProps extends ReactNative.ViewProperties {
 export const Svg: React.ComponentClass<SvgProps>;
 export default Svg;
 
-export interface SymbolsProps {
+export interface SymbolProps {
   id: string,
   viewBox?: string,
   preserveAspectRatio?: string,
 }
-export const Symbols: React.ComponentClass<SymbolsProps>;
+export const Symbol: React.ComponentClass<SymbolProps>;
 
 export interface TSpanProps extends CommonPathProps, FontProps {
   dx?: NumberProp,
@@ -244,7 +244,7 @@ export const TextPath: React.ComponentClass<TextPathProps>;
 
 export interface UseProps extends CommonPathProps {
   href: string,
-  width?: NumberProp,
-  height?: NumberProp,
+  width?: string,
+  height?: string,
 }
 export const Use: React.ComponentClass<UseProps>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,65 @@ type NumberProp = string | number;
 
 export type FillRule = 'evenodd' | 'nonzero';
 export type Units = 'userSpaceOnUse' | 'objectBoundingBox';
+
 export type TextAnchor = 'start' | 'middle' | 'end';
+export type FontStyle = 'normal' | 'italic' | 'oblique';
+export type FontVariant = 'normal' | 'small-caps';
+export type FontWeight =
+  | 'normal'
+  | 'bold'
+  | 'bolder'
+  | 'lighter'
+  | '100'
+  | '200'
+  | '300'
+  | '400'
+  | '500'
+  | '600'
+  | '700'
+  | '800'
+  | '900'
+  ;
+export type FontStretch =
+  | 'normal'
+  | 'wider'
+  | 'narrower'
+  | 'ultra-condensed'
+  | 'extra-condensed'
+  | 'condensed'
+  | 'semi-condensed'
+  | 'semi-expanded'
+  | 'expanded'
+  | 'extra-expanded'
+  | 'ultra-expanded'
+  ;
+export type TextDecoration = 'none' | 'underline' | 'overline' | 'line-through' | 'blink';
+export type FontVariantLigatures = 'normal' | 'none';
+export type AlignmentBaseline =
+  | 'baseline'
+  | 'text-bottom'
+  | 'alphabetic'
+  | 'ideographic'
+  | 'middle'
+  | 'central'
+  | 'mathematical'
+  | 'text-top'
+  | 'bottom'
+  | 'center'
+  | 'top'
+  | 'text-before-edge'
+  | 'text-after-edge'
+  | 'before-edge'
+  | 'after-edge'
+  | 'hanging'
+  ;
+export type BaselineShift = 'sub' | 'super' | 'baseline' | ReadonlyArray<NumberProp> | NumberProp;
+export type LengthAdjust = 'spacing' | 'spacingAndGlyphs';
+
+export type TextPathMethod = 'align' | 'stretch';
+export type TextPathSpacing = 'auto' | 'exact';
+export type TextPathMidLine = 'sharp' | 'smooth';
+
 export type Linecap = 'butt' | 'square' | 'round';
 export type Linejoin = 'miter' | 'bevel' | 'round';
 
@@ -44,19 +102,30 @@ export interface StrokeProps {
   stroke?: string,
   strokeWidth?: NumberProp,
   strokeOpacity?: NumberProp,
-  strokeDasharray?: number[] | string,
+  strokeDasharray?: ReadonlyArray<number> | string,
   strokeDashoffset?: NumberProp,
   strokeLinecap?: Linecap,
   strokeLinejoin?: Linejoin,
   strokeMiterlimit?: NumberProp,
 }
 
-export interface FontProps {
-  fontFamily?: string,
+export interface FontObject {
+  fontStyle?: FontStyle,
+  fontVariant?: FontVariant,
+  fontWeight?: FontWeight,
+  fontStretch?: FontStretch,
   fontSize?: NumberProp,
-  fontWeight?: NumberProp,
-  fontStyle?: string,
-  font?: object
+  fontFamily?: string,
+  textAnchor?: TextAnchor,
+  textDecoration?: TextDecoration,
+  letterSpacing?: NumberProp,
+  wordSpacing?: NumberProp,
+  kerning?: NumberProp,
+  fontVariantLigatures?: FontVariantLigatures,
+}
+
+export interface FontProps extends FontObject {
+  font?: FontObject,
 }
 
 export interface TransformObject {
@@ -112,14 +181,12 @@ export interface GProps extends CommonPathProps {
 }
 export const G: React.ComponentClass<GProps>;
 
-export type ImageHref = ReactNative.ImageURISource | ReactNative.ImageURISource[] | ReactNative.ImageRequireSource;
-
 export interface ImageProps extends ResponderProps, TouchableProps {
   x?: NumberProp,
   y?: NumberProp,
   width?: NumberProp,
   height?: NumberProp,
-  href: ImageHref,
+  href: ReactNative.ImageProperties['source'],
   preserveAspectRatio?: string,
 }
 export const Image: React.ComponentClass<ImageProps>;
@@ -159,12 +226,12 @@ export interface PatternProps {
 export const Pattern: React.ComponentClass<PatternProps>;
 
 export interface PolygonProps extends CommonPathProps {
-  points: string | any[],
+  points: string | ReadonlyArray<any>,
 }
 export const Polygon: React.ComponentClass<PolygonProps>;
 
 export interface PolylineProps extends CommonPathProps {
-  points: string | any[],
+  points: string | ReadonlyArray<any>,
 }
 export const Polyline: React.ComponentClass<PolylineProps>;
 
@@ -221,20 +288,31 @@ export const Symbol: React.ComponentClass<SymbolProps>;
 export interface TSpanProps extends CommonPathProps, FontProps {
   dx?: NumberProp,
   dy?: NumberProp,
-  textAnchor?: TextAnchor,
 }
 export const TSpan: React.ComponentClass<TSpanProps>;
 
-export interface TextProps extends CommonPathProps, FontProps {
+export interface TextSpecificProps extends CommonPathProps, FontProps {
+  alignmentBaseline: AlignmentBaseline,
+  baselineShift: BaselineShift,
+  verticalAlign: NumberProp,
+  lengthAdjust: LengthAdjust,
+  textLength: NumberProp,
+  fontData?: null | { [name: string]: any },
+  fontFeatureSettings?: string,
+}
+
+export interface TextProps extends TextSpecificProps {
   dx?: NumberProp,
   dy?: NumberProp,
-  textAnchor?: TextAnchor,
 }
 export const Text: React.ComponentClass<TextProps>;
 
-export interface TextPathProps extends CommonPathProps, FontProps {
+export interface TextPathProps extends TextSpecificProps {
   href: string,
   startOffset?: NumberProp,
+  method?: TextPathMethod,
+  spacing?: TextPathSpacing,
+  midLine: TextPathMidLine,
 }
 export const TextPath: React.ComponentClass<TextPathProps>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,7 @@ export interface ClipProps {
 }
 
 export interface DefinitionProps {
-  name?: string,
+  id?: string,
 }
 
 export interface StrokeProps {
@@ -192,10 +192,6 @@ export interface RectProps extends CommonPathProps {
 }
 export const Rect: React.ComponentClass<RectProps>;
 
-export interface ShapeProps {
-}
-export const Shape: React.ComponentClass<ShapeProps>;
-
 export interface StopProps {
   stopColor?: string,
   stopOpacity?: NumberProp,
@@ -244,7 +240,7 @@ export const TextPath: React.ComponentClass<TextPathProps>;
 
 export interface UseProps extends CommonPathProps {
   href: string,
-  width?: string,
-  height?: string,
+  width: string,
+  height: string,
 }
 export const Use: React.ComponentClass<UseProps>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -292,11 +292,11 @@ export interface TSpanProps extends CommonPathProps, FontProps {
 export const TSpan: React.ComponentClass<TSpanProps>;
 
 export interface TextSpecificProps extends CommonPathProps, FontProps {
-  alignmentBaseline: AlignmentBaseline,
-  baselineShift: BaselineShift,
-  verticalAlign: NumberProp,
-  lengthAdjust: LengthAdjust,
-  textLength: NumberProp,
+  alignmentBaseline?: AlignmentBaseline,
+  baselineShift?: BaselineShift,
+  verticalAlign?: NumberProp,
+  lengthAdjust?: LengthAdjust,
+  textLength?: NumberProp,
   fontData?: null | { [name: string]: any },
   fontFeatureSettings?: string,
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,13 @@ import * as ReactNative from 'react-native';
 // Common props
 type NumberProp = string | number;
 
-interface TouchableProps {
+export type FillRule = 'evenodd' | 'nonzero';
+export type Units = 'userSpaceOnUse' | 'objectBoundingBox';
+export type TextAnchor = 'start' | 'middle' | 'end';
+export type Linecap = 'butt' | 'square' | 'round';
+export type Linejoin = 'miter' | 'bevel' | 'round';
+
+export interface TouchableProps {
   disabled?: boolean,
   onPress?: (event: any) => any,
   onPressIn?: (event: any) => any,
@@ -15,37 +21,37 @@ interface TouchableProps {
   delayLongPress?: number
 }
 
-interface ResponderProps extends ReactNative.GestureResponderHandlers {
+export interface ResponderProps extends ReactNative.GestureResponderHandlers {
   pointerEvents?: (event: any) => any,
 }
 
-interface FillProps {
+export interface FillProps {
   fill?: string,
   fillOpacity?: NumberProp,
-  fillRule?: 'evenodd' | 'nonzero',
+  fillRule?: FillRule,
 }
 
-interface ClipProps {
-  clipRule?: 'evenodd' | 'nonzero',
+export interface ClipProps {
+  clipRule?: FillRule,
   clipPath?: string
 }
 
-interface DefinationProps {
+export interface DefinitionProps {
   name?: string,
 }
 
-interface StrokeProps {
+export interface StrokeProps {
   stroke?: string,
   strokeWidth?: NumberProp,
   strokeOpacity?: NumberProp,
   strokeDasharray?: number[] | string,
   strokeDashoffset?: NumberProp,
-  strokeLinecap?: 'butt' | 'square' | 'round',
-  strokeLinejoin?: 'miter' | 'bevel' | 'round',
+  strokeLinecap?: Linecap,
+  strokeLinejoin?: Linejoin,
   strokeMiterlimit?: NumberProp,
 }
 
-interface FontProps {
+export interface FontProps {
   fontFamily?: string,
   fontSize?: NumberProp,
   fontWeight?: NumberProp,
@@ -53,7 +59,7 @@ interface FontProps {
   font?: object
 }
 
-interface TransformProps {
+export interface TransformObject {
   scale?: NumberProp,
   scaleX?: NumberProp,
   scaleY?: NumberProp,
@@ -70,28 +76,31 @@ interface TransformProps {
   skew?: NumberProp,
   skewX?: NumberProp,
   skewY?: NumberProp,
-  transform?: object,
 }
 
-interface PathProps extends FillProps, StrokeProps, ClipProps, TransformProps, ResponderProps, TouchableProps, DefinationProps {}
+export interface TransformProps extends TransformObject {
+  transform?: string | TransformObject,
+}
+
+export interface CommonPathProps extends FillProps, StrokeProps, ClipProps, TransformProps, ResponderProps, TouchableProps, DefinitionProps {}
 
 
 // Element props
-interface CircleProps extends PathProps {
+export interface CircleProps extends CommonPathProps {
   cx?: NumberProp,
   cy?: NumberProp,
   r?: NumberProp,
 }
 export const Circle: React.ComponentClass<CircleProps>;
 
-interface ClipPathProps {
+export interface ClipPathProps {
   id: string,
 }
 export const ClipPath: React.ComponentClass<ClipPathProps>;
 
 export const Defs: React.ComponentClass<{}>;
 
-interface EllipseProps extends PathProps {
+export interface EllipseProps extends CommonPathProps {
   cx?: NumberProp,
   cy?: NumberProp,
   rx?: NumberProp,
@@ -99,19 +108,23 @@ interface EllipseProps extends PathProps {
 }
 export const Ellipse: React.ComponentClass<EllipseProps>;
 
-export const G: React.ComponentClass<PathProps>;
+export interface GProps extends CommonPathProps {
+}
+export const G: React.ComponentClass<GProps>;
 
-interface ImageProps extends ResponderProps, TouchableProps {
+export type ImageHref = ReactNative.ImageURISource | ReactNative.ImageURISource[] | ReactNative.ImageRequireSource;
+
+export interface ImageProps extends ResponderProps, TouchableProps {
   x?: NumberProp,
   y?: NumberProp,
   width?: NumberProp,
   height?: NumberProp,
-  href: ReactNative.ImageURISource | ReactNative.ImageURISource[] | ReactNative.ImageRequireSource,
+  href: ImageHref,
   preserveAspectRatio?: string,
 }
 export const Image: React.ComponentClass<ImageProps>;
 
-interface LineProps extends PathProps {
+export interface LineProps extends CommonPathProps {
   x1?: NumberProp,
   x2?: NumberProp,
   y1?: NumberProp,
@@ -119,43 +132,43 @@ interface LineProps extends PathProps {
 }
 export const Line: React.ComponentClass<LineProps>;
 
-interface LinearGradientProps {
+export interface LinearGradientProps {
   x1?: NumberProp,
   x2?: NumberProp,
   y1?: NumberProp,
   y2?: NumberProp,
-  gradientUnits?: 'objectBoundingBox' | 'userSpaceOnUse',
+  gradientUnits?: Units,
   id: string,
 }
 export const LinearGradient: React.ComponentClass<LinearGradientProps>;
 
-interface PathElementProps extends PathProps {
+export interface PathProps extends CommonPathProps {
   d: string,
 }
-export const Path: React.ComponentClass<PathElementProps>;
+export const Path: React.ComponentClass<PathProps>;
 
-interface PatternProps {
+export interface PatternProps {
   x1?: NumberProp,
   x2?: NumberProp,
   y1?: NumberProp,
   y2?: NumberProp,
   patternTransform?: string,
-  patternUnits?: 'userSpaceOnUse' | 'objectBoundingBox',
-  patternContentUnits?: 'userSpaceOnUse' | 'objectBoundingBox',
+  patternUnits?: Units,
+  patternContentUnits?: Units,
 }
 export const Pattern: React.ComponentClass<PatternProps>;
 
-interface PolygonProps extends PathProps {
+export interface PolygonProps extends CommonPathProps {
   points: string | any[],
 }
 export const Polygon: React.ComponentClass<PolygonProps>;
 
-interface PolylineProps extends PathProps {
+export interface PolylineProps extends CommonPathProps {
   points: string | any[],
 }
 export const Polyline: React.ComponentClass<PolylineProps>;
 
-interface RadialGradientProps {
+export interface RadialGradientProps {
   fx?: NumberProp,
   fy?: NumberProp,
   rx?: NumberProp,
@@ -163,70 +176,73 @@ interface RadialGradientProps {
   cx?: NumberProp,
   cy?: NumberProp,
   r?: NumberProp,
-  gradientUnits: 'objectBoundingBox' | 'userSpaceOnUse',
+  gradientUnits?: Units,
   id: string,
 }
 export const RadialGradient: React.ComponentClass<RadialGradientProps>;
 
-interface RectProps extends PathProps {
+export interface RectProps extends CommonPathProps {
   x?: NumberProp,
   y?: NumberProp,
   width?: NumberProp,
   height?: NumberProp,
   rx?: NumberProp,
   ry?: NumberProp,
-    class? : string
+  class?: string,
 }
 export const Rect: React.ComponentClass<RectProps>;
 
-export const Shape: React.ComponentClass<{}>;
+export interface ShapeProps {
+}
+export const Shape: React.ComponentClass<ShapeProps>;
 
-interface StopProps {
+export interface StopProps {
   stopColor?: string,
   stopOpacity?: NumberProp,
-    offset?: string
+  offset?: string,
 }
 export const Stop: React.ComponentClass<StopProps>;
 
-interface SvgProps extends ReactNative.ViewProperties {
+export interface SvgProps extends ReactNative.ViewProperties {
   opacity?: NumberProp,
   width?: NumberProp,
   height?: NumberProp,
   viewBox?: string,
-  preserveAspectRatio?: string
+  preserveAspectRatio?: string,
 }
 
-declare const Svg: React.ComponentClass<SvgProps>;
+// Svg is both regular and default exported
+export const Svg: React.ComponentClass<SvgProps>;
 export default Svg;
 
-interface SymbolsProps {
+export interface SymbolsProps {
   id: string,
   viewBox?: string,
   preserveAspectRatio?: string,
 }
 export const Symbols: React.ComponentClass<SymbolsProps>;
 
-interface TSpanProps extends PathProps, FontProps {
+export interface TSpanProps extends CommonPathProps, FontProps {
   dx?: NumberProp,
   dy?: NumberProp,
-  textAnchor?: 'start' | 'middle' | 'end',
+  textAnchor?: TextAnchor,
 }
 export const TSpan: React.ComponentClass<TSpanProps>;
 
-interface TextProps extends PathProps, FontProps {
+export interface TextProps extends CommonPathProps, FontProps {
   dx?: NumberProp,
   dy?: NumberProp,
-  textAnchor?: 'start' | 'middle' | 'end',
+  textAnchor?: TextAnchor,
 }
 export const Text: React.ComponentClass<TextProps>;
 
-interface TextPathProps extends PathProps, FontProps {
+export interface TextPathProps extends CommonPathProps, FontProps {
   href: string,
   startOffset?: NumberProp,
 }
 export const TextPath: React.ComponentClass<TextPathProps>;
 
-interface UseProps extends PathProps {
+export interface UseProps extends CommonPathProps {
   href: string,
   width?: NumberProp,
   height?: NumberProp,


### PR DESCRIPTION
## Changes

Adds exports for all the type definitions (except `NumberProp`)

Also:
- Extracts and exports the string literal union types
- Adds or renames prop types such that every `Foo`
  component export also has a `FooProps`
- Adds non-default export of `Svg`, so `import * as Svg ...`
  is usable.
- Makes `RadialGradientProps.gradientUnits` optional, like
  for `LinearGradientProps.gradientUnits`.
- Adds stronger type for `TransformProps.transform` based
  on code in `extractTranform.js` (please double-check!)
- Fixes typo in `DefinationProps` name.
- A handful of minor formatting normalizations.

I also found and put a type fix for the following issues:
- `Symbols` -> `Symbol` (!)
- `Use` errors unless `width` and `height` are provided, and strings? This seems like a bug.
- `Svg` errors if `width` and `height` are not provided? This one looks like it comes from RN, since it talks about `Surface`?
- `Definitions` have an `id`, not a `name`.
- There is no `Shape` export.

## Example

```ts
import React from "react";
import * as Svg from "react-native-svg";

const defaultStrokeProps: Svg.StrokeProps = {
  stroke: 'black',
  strokeLinejoin: 'round',
};
export interface ExampleProps {
  strokeProps?: Svg.StrokeProps;
}
export default ({ strokeProps = {} }: ExampleProps) => (
  <Svg.Svg width={50} height={50}>
    <Svg.Rect x={0} y={0} width={50} height={50} {...defaultStrokeProps} {...strokeProps} />
  </Svg.Svg>
);
```

In particular, note that without a type, `defaultStrokeProps` will type `strokeLinejoin` as `string`, which will cause a type error when spreading.

## Questions

1. I could make a precise type for `PreserveAspectRatio`, but it expands out pretty bad: 40 different combinations. Since it's fairly likely this could be computed (e.g. `x${alignX}Y${alignY}`), I'm not sure if this would be better? On the other hand, it's a very easy to typo value written literally!
2. Should `NumberProp` be exported? It is trivial but so commonly used simply having an authoritative name could be useful. Perhaps it could change to use https://github.com/Microsoft/TypeScript/issues/6579 later?
3. Feedback on naming of the enum types would be good: in particular,:
  - Should they have a `Prop` suffix like `NumberProp`? Feels too confusable with `Props` to me.
  - `FillRule` is used for `FillProps.fillRule` and `ClipProps.clipRule`, but I'm not sure what a better name would be?
4. In my `react-dom` SVG rendering code, I currently render defs without `id` then use `React.cloneElement(def, { key, id })` to share generating ids for these: would it be OK to make these optional?