### PR TITLE
Add support for react-native-web

### DIFF
--- a/elements/Circle.js
+++ b/elements/Circle.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
+import { createReactNativeComponentClass }  from '../lib/nativeComponents';
 import Shape from './Shape';
 import {CircleAttributes} from '../lib/attributes';
 import {pathProps, numberProp} from '../lib/props';

--- a/elements/ClipPath.js
+++ b/elements/ClipPath.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
+import { createReactNativeComponentClass }  from '../lib/nativeComponents';
 import {ClipPathAttributes} from '../lib/attributes';
 
 export default class extends Component{

--- a/elements/Defs.js
+++ b/elements/Defs.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
+import { createReactNativeComponentClass }  from '../lib/nativeComponents';
 
 export default class extends Component {
     static displayName = 'Defs';

--- a/elements/Ellipse.js
+++ b/elements/Ellipse.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
+import { createReactNativeComponentClass }  from '../lib/nativeComponents';
 import Shape from './Shape';
 import {pathProps, numberProp} from '../lib/props';
 import {EllipseAttributes} from '../lib/attributes';

--- a/elements/G.js
+++ b/elements/G.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
+import { createReactNativeComponentClass }  from '../lib/nativeComponents';
 import Shape from './Shape';
 import {pathProps, fontProps} from '../lib/props';
 import {GroupAttributes} from '../lib/attributes';

--- a/elements/Image.js
+++ b/elements/Image.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Image } from 'react-native';
-import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
+import { createReactNativeComponentClass }  from '../lib/nativeComponents';
 import {ImageAttributes} from '../lib/attributes';
 import {numberProp, touchableProps, responderProps} from '../lib/props';
 import Shape from './Shape';

--- a/elements/Image.web.js
+++ b/elements/Image.web.js
@@ -1,7 +1,7 @@
-import Shape from './Shape'
+import Shape from './Shape';
 export default class extends Shape {
 
     render() {
-        return <image {...this.props} />
+        return <image {...this.props} />;
     }
 }

--- a/elements/Image.web.js
+++ b/elements/Image.web.js
@@ -1,0 +1,7 @@
+import Shape from './Shape'
+export default class extends Shape {
+
+    render() {
+        return <image {...this.props} />
+    }
+}

--- a/elements/Line.js
+++ b/elements/Line.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
+import { createReactNativeComponentClass }  from '../lib/nativeComponents';
 import {LineAttributes} from '../lib/attributes';
 import Shape from './Shape';
 import {pathProps, numberProp} from '../lib/props';

--- a/elements/LinearGradient.js
+++ b/elements/LinearGradient.js
@@ -2,7 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {numberProp} from '../lib/props';
 import extractGradient from '../lib/extract/extractGradient';
-import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
+import { createReactNativeComponentClass }  from '../lib/nativeComponents';
 import {LinearGradientAttributes} from '../lib/attributes';
 
 export default class extends Component{

--- a/elements/Path.js
+++ b/elements/Path.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
+import { createReactNativeComponentClass }  from '../lib/nativeComponents';
 import {PathAttributes} from '../lib/attributes';
 import Shape from './Shape';
 import {pathProps} from '../lib/props';

--- a/elements/RadialGradient.js
+++ b/elements/RadialGradient.js
@@ -2,7 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {numberProp} from '../lib/props';
 import extractGradient from '../lib/extract/extractGradient';
-import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
+import { createReactNativeComponentClass }  from '../lib/nativeComponents';
 import {RadialGradientAttributes} from '../lib/attributes';
 
 export default class extends Component{

--- a/elements/Rect.js
+++ b/elements/Rect.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import './Path'; // must import Path first, don`t know why. without this will throw an `Super expression must either be null or a function, not undefined`
-import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
+import { createReactNativeComponentClass }  from '../lib/nativeComponents';
 import {pathProps, numberProp} from '../lib/props';
 import {RectAttributes} from '../lib/attributes';
 import extractProps from '../lib/extract/extractProps';

--- a/elements/Stop.web.js
+++ b/elements/Stop.web.js
@@ -1,0 +1,2 @@
+import React, {Component} from 'react';
+export default (props) => <stop {...props} />

--- a/elements/Stop.web.js
+++ b/elements/Stop.web.js
@@ -1,2 +1,2 @@
-import React, {Component} from 'react';
-export default (props) => <stop {...props} />
+import React from 'react';
+export default (props) => <stop {...props} />;

--- a/elements/Svg.js
+++ b/elements/Svg.js
@@ -5,11 +5,11 @@ import React, {
 import PropTypes from 'prop-types';
 import {
     ViewPropTypes,
-    requireNativeComponent,
     StyleSheet,
     findNodeHandle,
     NativeModules
 } from 'react-native';
+import {requireNativeComponent} from '../lib/nativeComponents'
 import extractViewBox from '../lib/extract/extractViewBox';
 import {ViewBoxAttributes} from '../lib/attributes';
 

--- a/elements/Svg.web.js
+++ b/elements/Svg.web.js
@@ -1,0 +1,2 @@
+import React, {Component} from 'react';
+export default(props)=><svg {...props} />

--- a/elements/Svg.web.js
+++ b/elements/Svg.web.js
@@ -1,2 +1,2 @@
-import React, {Component} from 'react';
-export default(props)=><svg {...props} />
+import React from 'react';
+export default(props)=><svg {...props} />;

--- a/elements/Symbol.js
+++ b/elements/Symbol.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import extractViewBox from '../lib/extract/extractViewBox';
-import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
+import { createReactNativeComponentClass }  from '../lib/nativeComponents';
 import {SymbolAttributes} from '../lib/attributes';
 
 export default class extends Component{

--- a/elements/TSpan.js
+++ b/elements/TSpan.js
@@ -1,6 +1,6 @@
 import React  from 'react';
 import PropTypes from 'prop-types';
-import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
+import { createReactNativeComponentClass }  from '../lib/nativeComponents';
 import extractText from '../lib/extract/extractText';
 import {textProps} from '../lib/props';
 import {TSpanAttibutes} from '../lib/attributes';

--- a/elements/Text.js
+++ b/elements/Text.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
+import { createReactNativeComponentClass }  from '../lib/nativeComponents';
 import extractText from '../lib/extract/extractText';
 import {textProps} from '../lib/props';
 import {TextAttributes} from '../lib/attributes';

--- a/elements/TextPath.js
+++ b/elements/TextPath.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
+import { createReactNativeComponentClass }  from '../lib/nativeComponents';
 import {TextPathAttributes} from '../lib/attributes';
 import extractText from '../lib/extract/extractText';
 import Shape from './Shape';

--- a/elements/Use.js
+++ b/elements/Use.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import createReactNativeComponentClass from '../lib/createReactNativeComponentClass';
+import { createReactNativeComponentClass }  from '../lib/nativeComponents';
 import extractProps from '../lib/extract/extractProps';
 import {pathProps, numberProp} from '../lib/props';
 import {UseAttributes} from '../lib/attributes';

--- a/lib/SvgTouchableMixin.js
+++ b/lib/SvgTouchableMixin.js
@@ -1,4 +1,4 @@
-import Touchable from 'react-native/Libraries/Components/Touchable/Touchable';
+import {Touchable} from 'react-native';
 const PRESS_RETENTION_OFFSET = {top: 20, left: 20, right: 20, bottom: 30};
 
 //noinspection JSUnusedGlobalSymbols

--- a/lib/createReactNativeComponentClass.js
+++ b/lib/createReactNativeComponentClass.js
@@ -1,6 +1,0 @@
-import createReactNativeComponentClass from 'react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js'
-
-export default (uiViewClassName, getViewConfig) =>
-  createReactNativeComponentClass.length >= 2
-    ? createReactNativeComponentClass(uiViewClassName, getViewConfig)
-    : createReactNativeComponentClass(getViewConfig())

--- a/lib/extract/extractGradient.web.js
+++ b/lib/extract/extractGradient.web.js
@@ -1,0 +1,3 @@
+export default function(props) {
+    return props;
+}

--- a/lib/extract/extractProps.web.js
+++ b/lib/extract/extractProps.web.js
@@ -1,16 +1,16 @@
 function replaceKey(obj,old_key, new_key) {
-    if(obj[old_key]){
-        console.log("replacing:", old_key, " with ",  new_key);
-      obj[old_key] = ob[new_key];
+    if (obj[old_key]){
+        console.log('replacing:', old_key, ' with ',  new_key);
+      obj[old_key] = obj[new_key];
       delete obj[old_key];
   }
-};
+}
 export default function(props, ref) {
     // translate from the react-native-svg to HTML svg props
-    replaceKey(props,"deltaX","dx");
-    replaceKey(props,"deltaY","dy");
-    replaceKey(props,"positionX","x");
-    replaceKey(props,"positionY","y");
+    replaceKey(props,'deltaX','dx');
+    replaceKey(props,'deltaY','dy');
+    replaceKey(props,'positionX','x');
+    replaceKey(props,'positionY','y');
 
     return props;
 }

--- a/lib/extract/extractProps.web.js
+++ b/lib/extract/extractProps.web.js
@@ -1,0 +1,16 @@
+function replaceKey(obj,old_key, new_key) {
+    if(obj[old_key]){
+        console.log("replacing:", old_key, " with ",  new_key);
+      obj[old_key] = ob[new_key];
+      delete obj[old_key];
+  }
+};
+export default function(props, ref) {
+    // translate from the react-native-svg to HTML svg props
+    replaceKey(props,"deltaX","dx");
+    replaceKey(props,"deltaY","dy");
+    replaceKey(props,"positionX","x");
+    replaceKey(props,"positionY","y");
+
+    return props;
+}

--- a/lib/extract/extractText.js
+++ b/lib/extract/extractText.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 //noinspection JSUnresolvedVariable
 import React, {Children} from 'react';
+import {Platform} from 'react-native';
 import TSpan from '../../elements/TSpan';
 import extractLengthList from './extractLengthList';
 
@@ -92,6 +93,8 @@ export function extractFont(props) {
 }
 
 export default function(props, container) {
+    // don't do any parsing for web platform
+   if(Platform.OS === 'web') return props;
     const {
         x,
         y,

--- a/lib/nativeComponents.js
+++ b/lib/nativeComponents.js
@@ -1,11 +1,10 @@
-import createReactNativeComponentClass from 'react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js'
-import {requireNativeComponent} from 'react-native'
+import nativeCreateReactNativeComponentClass from 'react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js'
+import {requireNativeComponent as nativeRequireNativeComponent} from 'react-native'
 
-export function createReactNativeComponentClass(uiViewClassName, getViewConfig) {
-    return createReactNativeComponentClass.length >= 2
-        ? createReactNativeComponentClass(uiViewClassName, getViewConfig)
-        : createReactNativeComponentClass(getViewConfig())
+export function createReactNativeComponentClass (uiViewClassName, getViewConfig) {
+    return nativeCreateReactNativeComponentClass.length >= 2
+        ? nativeCreateReactNativeComponentClass(uiViewClassName, getViewConfig)
+        : nativeCreateReactNativeComponentClass(getViewConfig());
 }
 
-//pass through for ios and android
-export requireNativeComponent;
+export let requireNativeComponent = nativeRequireNativeComponent;

--- a/lib/nativeComponents.js
+++ b/lib/nativeComponents.js
@@ -1,0 +1,11 @@
+import createReactNativeComponentClass from 'react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js'
+import {requireNativeComponent} from 'react-native'
+
+export function createReactNativeComponentClass(uiViewClassName, getViewConfig) {
+    return createReactNativeComponentClass.length >= 2
+        ? createReactNativeComponentClass(uiViewClassName, getViewConfig)
+        : createReactNativeComponentClass(getViewConfig())
+}
+
+//pass through for ios and android
+export requireNativeComponent;

--- a/lib/nativeComponents.web.js
+++ b/lib/nativeComponents.web.js
@@ -17,7 +17,7 @@ function createWebComponent(WrappedComponent, extraConfig) {
         }
 
         render() {
-            return (<WrappedComponent {...this.props}  />)
+            return (<WrappedComponent {...this.props}  />);
         }
     }
 
@@ -27,38 +27,38 @@ function createWebComponent(WrappedComponent, extraConfig) {
 
 // map from react-svg component name to web implementation
 const webComponentMap = {
-    "RNSVGSvgView": (props) => <svg {...props} />,
-    "RNSVGCircle": (props) => <circle {...props} />,
-    "RNSVGClipPath": (props) =>  {
+    'RNSVGSvgView': (props) => <svg {...props} />,
+    'RNSVGCircle': (props) => <circle {...props} />,
+    'RNSVGClipPath': (props) =>  {
         let {name, ...new_props} = props;
-        return <clipPath id={name} {...new_props} />
+        return <clipPath id={name} {...new_props} />;
     },
-    "RNSVGEllipse": (props) => <ellipse {...props} />,
-    "RNSVGGroup": (props) => <g {...props} />,
-    "RNSVGLine": (props) => <line {...props} />,
-    "RNSVGLinearGradient": (props) => <linearGradient {...props} />,
-    "RNSVGPath": (props) => <path {...props} />,
-    "RNSVGPattern": (props) => <pattern {...props} />,
-    "RNSVGPolygon": (props) => <polygon {...props} />,
-    "RNSVGPolyLine": (props) => <polyline {...props} />,
-    "RNSVGRadialGradient": (props) => <radialGradient {...props} />,
-    "RNSVGRect": (props) => <rect {...props} />,
-    "RNSVGStop": (props) => <stop {...props} />,
-    "RNSVGSymbol": (props) => <symbol {...props} />,
-    "RNSVGText": (props) => <text {...props} />,
-    "RNSVGTextPath": (props) => <textPath {...props} />,
-    "RNSVGTSpan": (props) => <tspan {...props} />,
-    "RNSVGUse": (props) => {
+    'RNSVGEllipse': (props) => <ellipse {...props} />,
+    'RNSVGGroup': (props) => <g {...props} />,
+    'RNSVGLine': (props) => <line {...props} />,
+    'RNSVGLinearGradient': (props) => <linearGradient {...props} />,
+    'RNSVGPath': (props) => <path {...props} />,
+    'RNSVGPattern': (props) => <pattern {...props} />,
+    'RNSVGPolygon': (props) => <polygon {...props} />,
+    'RNSVGPolyLine': (props) => <polyline {...props} />,
+    'RNSVGRadialGradient': (props) => <radialGradient {...props} />,
+    'RNSVGRect': (props) => <rect {...props} />,
+    'RNSVGStop': (props) => <stop {...props} />,
+    'RNSVGSymbol': (props) => <symbol {...props} />,
+    'RNSVGText': (props) => <text {...props} />,
+    'RNSVGTextPath': (props) => <textPath {...props} />,
+    'RNSVGTSpan': (props) => <tspan {...props} />,
+    'RNSVGUse': (props) => {
         let {href, ...new_props} = props;
-        return <use xlinkHref={href} {...new_props} />
+        return <use xlinkHref={href} {...new_props} />;
     },
-    "RNSVGDefs": (props) => <defs {...props} />,
+    'RNSVGDefs': (props) => <defs {...props} />
 };
 
 
 export function requireNativeComponent(viewName, componentInterface, extraConfig){
     let WebComponent = webComponentMap[viewName];
-    if(!WebComponent) throw new Error("No such web component :" + viewName);
+    if (!WebComponent)  { throw new Error('No such web component :' + viewName); }
 
     return createWebComponent(WebComponent, extraConfig);
 }

--- a/lib/nativeComponents.web.js
+++ b/lib/nativeComponents.web.js
@@ -1,0 +1,68 @@
+import React, {
+    Component
+} from 'react';
+
+
+
+function createWebComponent(WrappedComponent, extraConfig) {
+    // Create a custom stateful class-based component to
+    // wrap the functional component  (that way ref workds)
+    // and include the extraConfig that would have been passed
+    // to the native component
+    class WrappingWebComponent extends Component {
+
+        constructor(props) {
+            super(props);
+            this.extraConfig = extraConfig;
+        }
+
+        render() {
+            return (<WrappedComponent {...this.props}  />)
+        }
+    }
+
+    return WrappingWebComponent;
+}
+
+
+// map from react-svg component name to web implementation
+const webComponentMap = {
+    "RNSVGSvgView": (props) => <svg {...props} />,
+    "RNSVGCircle": (props) => <circle {...props} />,
+    "RNSVGClipPath": (props) =>  {
+        let {name, ...new_props} = props;
+        return <clipPath id={name} {...new_props} />
+    },
+    "RNSVGEllipse": (props) => <ellipse {...props} />,
+    "RNSVGGroup": (props) => <g {...props} />,
+    "RNSVGLine": (props) => <line {...props} />,
+    "RNSVGLinearGradient": (props) => <linearGradient {...props} />,
+    "RNSVGPath": (props) => <path {...props} />,
+    "RNSVGPattern": (props) => <pattern {...props} />,
+    "RNSVGPolygon": (props) => <polygon {...props} />,
+    "RNSVGPolyLine": (props) => <polyline {...props} />,
+    "RNSVGRadialGradient": (props) => <radialGradient {...props} />,
+    "RNSVGRect": (props) => <rect {...props} />,
+    "RNSVGStop": (props) => <stop {...props} />,
+    "RNSVGSymbol": (props) => <symbol {...props} />,
+    "RNSVGText": (props) => <text {...props} />,
+    "RNSVGTextPath": (props) => <textPath {...props} />,
+    "RNSVGTSpan": (props) => <tspan {...props} />,
+    "RNSVGUse": (props) => {
+        let {href, ...new_props} = props;
+        return <use xlinkHref={href} {...new_props} />
+    },
+    "RNSVGDefs": (props) => <defs {...props} />,
+};
+
+
+export function requireNativeComponent(viewName, componentInterface, extraConfig){
+    let WebComponent = webComponentMap[viewName];
+    if(!WebComponent) throw new Error("No such web component :" + viewName);
+
+    return createWebComponent(WebComponent, extraConfig);
+}
+
+export function createReactNativeComponentClass(uiViewClassName, getViewConfig) {
+    return requireNativeComponent(uiViewClassName, null, getViewConfig);
+}

--- a/web/Svg.js
+++ b/web/Svg.js
@@ -1,0 +1,3 @@
+export default  function (props) {
+    return (<svg {...props} />)
+}


### PR DESCRIPTION
Added support for [react-native-web](https://github.com/necolas/react-native-web) so that SVG components can be shared between iOS, Android, and web. 

I attempted to touch the existing code as little as possible, though there was some custom logic needed for the Svg and Image components. In order to keep the abstraction that 'web' is just another native platform I made "RNSVG*"  'native' components with HTML that mirror the iOS and Android native components. 

Manually tested with a react-native-web app and android. 