### PR TITLE
Add "typedef" to NS_ENUM declarations, fix duplicate symbol error

### DIFF
--- a/ios/Text/AlignmentBaseline.h
+++ b/ios/Text/AlignmentBaseline.h
@@ -3,7 +3,7 @@
 
 #import <Foundation/Foundation.h>
 
-NS_ENUM(NSInteger, AlignmentBaseline) {
+typedef NS_ENUM(NSInteger, AlignmentBaseline) {
     AlignmentBaselineBaseline,
     AlignmentBaselineTextBottom,
     AlignmentBaselineAlphabetic,

--- a/ios/Text/FontStyle.h
+++ b/ios/Text/FontStyle.h
@@ -3,7 +3,7 @@
 #ifndef FontStyle_h
 #define FontStyle_h
 
-NS_ENUM(NSInteger, FontStyle) {
+typedef NS_ENUM(NSInteger, FontStyle) {
     FontStyleNormal,
     FontStyleItalic,
     FontStyleOblique,

--- a/ios/Text/FontVariantLigatures.h
+++ b/ios/Text/FontVariantLigatures.h
@@ -3,7 +3,7 @@
 #ifndef FontVariantLigatures_h
 #define FontVariantLigatures_h
 
-NS_ENUM(NSInteger, FontVariantLigatures) {
+typedef NS_ENUM(NSInteger, FontVariantLigatures) {
     FontVariantLigaturesNormal,
     FontVariantLigaturesNone,
     FontVariantLigaturesDEFAULT = FontVariantLigaturesNormal,

--- a/ios/Text/FontWeight.h
+++ b/ios/Text/FontWeight.h
@@ -3,7 +3,7 @@
 #ifndef FontWeight_h
 #define FontWeight_h
 
-NS_ENUM(NSInteger, FontWeight) {
+typedef NS_ENUM(NSInteger, FontWeight) {
     FontWeightNormal,
     FontWeightBold,
     FontWeightBolder,

--- a/ios/Text/TextAnchor.h
+++ b/ios/Text/TextAnchor.h
@@ -3,7 +3,7 @@
 #ifndef TextAnchor_h
 #define TextAnchor_h
 
-NS_ENUM(NSInteger, TextAnchor) {
+typedef NS_ENUM(NSInteger, TextAnchor) {
     TextAnchorStart,
     TextAnchorMiddle,
     TextAnchorEnd,

--- a/ios/Text/TextDecoration.h
+++ b/ios/Text/TextDecoration.h
@@ -3,7 +3,7 @@
 #ifndef TextDecoration_h
 #define TextDecoration_h
 
-NS_ENUM(NSInteger, TextDecoration) {
+typedef NS_ENUM(NSInteger, TextDecoration) {
     TextDecorationNone,
     TextDecorationUnderline,
     TextDecorationOverline,

--- a/ios/Text/TextLengthAdjust.h
+++ b/ios/Text/TextLengthAdjust.h
@@ -3,7 +3,7 @@
 #ifndef TextLengthAdjust_h
 #define TextLengthAdjust_h
 
-NS_ENUM(NSInteger, TextLengthAdjust) {
+typedef NS_ENUM(NSInteger, TextLengthAdjust) {
     TextLengthAdjustSpacing,
     TextLengthAdjustSpacingAndGlyphs,
     TextLengthAdjustDEFAULT = TextLengthAdjustSpacing,

--- a/ios/Text/TextPathMethod.h
+++ b/ios/Text/TextPathMethod.h
@@ -3,7 +3,7 @@
 #ifndef TextPathMethod_h
 #define TextPathMethod_h
 
-NS_ENUM(NSInteger, TextPathMethod) {
+typedef NS_ENUM(NSInteger, TextPathMethod) {
     TextPathMethodAlign,
     TextPathMethodStretch,
     TextPathMethodDEFAULT = TextPathMethodAlign,

--- a/ios/Text/TextPathMidLine.h
+++ b/ios/Text/TextPathMidLine.h
@@ -3,7 +3,7 @@
 #ifndef TextPathMidLine_h
 #define TextPathMidLine_h
 
-NS_ENUM(NSInteger, TextPathMidLine) {
+typedef NS_ENUM(NSInteger, TextPathMidLine) {
     TextPathMidLineSharp,
     TextPathMidLineSmooth,
     TextPathMidLineDEFAULT = TextPathMidLineSharp,

--- a/ios/Text/TextPathSide.h
+++ b/ios/Text/TextPathSide.h
@@ -3,7 +3,7 @@
 #ifndef TextPathSide_h
 #define TextPathSide_h
 
-NS_ENUM(NSInteger, TextPathSide) {
+typedef NS_ENUM(NSInteger, TextPathSide) {
     TextPathSideLeft,
     TextPathSideRight,
     TextPathSideDEFAULT = TextPathSideLeft,

--- a/ios/Text/TextPathSpacing.h
+++ b/ios/Text/TextPathSpacing.h
@@ -3,7 +3,7 @@
 #ifndef TextPathSpacing_h
 #define TextPathSpacing_h
 
-NS_ENUM(NSInteger, TextPathSpacing) {
+typedef NS_ENUM(NSInteger, TextPathSpacing) {
     TextPathSpacingAutoSpacing,
     TextPathSpacingExact,
     TextPathSpacingDEFAULT = TextPathSpacingAutoSpacing,


### PR DESCRIPTION
NS_ENUM is designed to go with typedef c.f. Apple docs: https://developer.apple.com/library/content/releasenotes/ObjectiveC/ModernizationObjC/AdoptingModernObjective-C/AdoptingModernObjective-C.html#//apple_ref/doc/uid/TP40014150-CH1-SW6

Fixes #579