### PR TITLE
Bugfix/278 memory leak issue

### DIFF
--- a/ios/Elements/RNSVGClipPath.m
+++ b/ios/Elements/RNSVGClipPath.m
@@ -17,7 +17,7 @@
 
 - (void)parseReference
 {
-    [[self getSvgView] defineClipPath:self clipPathName:self.name];
+    [self.svgView defineClipPath:self clipPathName:self.name];
 }
 
 

--- a/ios/Elements/RNSVGGroup.m
+++ b/ios/Elements/RNSVGGroup.m
@@ -33,10 +33,10 @@
 - (void)renderGroupTo:(CGContextRef)context
 {
     [self pushGlyphContext];
-    RNSVGSvgView* svg = [self getSvgView];
+    
     [self traverseSubviews:^(RNSVGNode *node) {
-        if (node.responsible && !svg.responsible) {
-            svg.responsible = YES;
+        if (node.responsible && !self.svgView.responsible) {
+            self.svgView.responsible = YES;
         }
 
         if ([node isKindOfClass:[RNSVGRenderable class]]) {
@@ -142,8 +142,8 @@
 - (void)parseReference
 {
     if (self.name) {
-        RNSVGSvgView* svg = [self getSvgView];
-        [svg defineTemplate:self templateName:self.name];
+        typeof(self) __weak weakSelf = self;
+        [self.svgView defineTemplate:weakSelf templateName:self.name];
     }
 
     [self traverseSubviews:^(__kindof RNSVGNode *node) {

--- a/ios/Elements/RNSVGGroup.m
+++ b/ios/Elements/RNSVGGroup.m
@@ -72,12 +72,13 @@
 
 - (void)pushGlyphContext
 {
-    [[[self getTextRoot] getGlyphContext] pushContext:self font:self.font];
+    __weak typeof(self) weakSelf = self;
+    [[self.textRoot getGlyphContext] pushContext:weakSelf font:self.font];
 }
 
 - (void)popGlyphContext
 {
-    [[[self getTextRoot] getGlyphContext] popContext];
+    [[self.textRoot getGlyphContext] popContext];
 }
 
 - (void)renderPathTo:(CGContextRef)context

--- a/ios/Elements/RNSVGLinearGradient.m
+++ b/ios/Elements/RNSVGLinearGradient.m
@@ -34,12 +34,11 @@
     [painter setTransform:self.gradientTransform];
     [painter setLinearGradientColors:self.gradient];
     
-    RNSVGSvgView *svg = [self getSvgView];
     if (self.gradientUnits == kRNSVGUnitsUserSpaceOnUse) {
-        [painter setUserSpaceBoundingBox:[svg getContextBounds]];
+        [painter setUserSpaceBoundingBox:[self.svgView getContextBounds]];
     }
     
-    [svg definePainter:painter painterName:self.name];
+    [self.svgView definePainter:painter painterName:self.name];
 }
 @end
 

--- a/ios/Elements/RNSVGRadialGradient.m
+++ b/ios/Elements/RNSVGRadialGradient.m
@@ -32,12 +32,11 @@
     [painter setTransform:self.gradientTransform];
     [painter setRadialGradientColors:self.gradient];
     
-    RNSVGSvgView *svg = [self getSvgView];
     if (self.gradientUnits == kRNSVGUnitsUserSpaceOnUse) {
-        [painter setUserSpaceBoundingBox:[svg getContextBounds]];
+        [painter setUserSpaceBoundingBox:[self.svgView getContextBounds]];
     }
     
-    [svg definePainter:painter painterName:self.name];
+    [self.svgView definePainter:painter painterName:self.name];
 }
 
 @end

--- a/ios/Elements/RNSVGUse.m
+++ b/ios/Elements/RNSVGUse.m
@@ -24,7 +24,7 @@
 
 - (void)renderLayerTo:(CGContextRef)context
 {
-    RNSVGNode* template = [[self getSvgView] getDefinedTemplate:self.href];
+    RNSVGNode* template = [self.svgView getDefinedTemplate:self.href];
     if (template) {
         [self beginTransparencyLayer:context];
         [self clip:context];

--- a/ios/RNSVGNode.h
+++ b/ios/RNSVGNode.h
@@ -34,6 +34,11 @@ extern CGFloat const RNSVG_DEFAULT_FONT_SIZE;
 @property (nonatomic, assign) CGAffineTransform matrix;
 @property (nonatomic, assign) BOOL active;
 
+/**
+ * RNSVGSvgView which ownes current RNSVGNode
+ */
+@property (nonatomic, readonly, weak) RNSVGSvgView *svgView;
+
 - (void)invalidate;
 
 - (RNSVGGroup *)getTextRoot;
@@ -72,11 +77,6 @@ extern CGFloat const RNSVG_DEFAULT_FONT_SIZE;
  * run hitTest
  */
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event withTransform:(CGAffineTransform)transfrom;
-
-/**
- * get RNSVGSvgView which ownes current RNSVGNode
- */
-- (RNSVGSvgView *)getSvgView;
 
 - (CGFloat)relativeOnWidth:(NSString *)length;
 

--- a/ios/RNSVGNode.h
+++ b/ios/RNSVGNode.h
@@ -38,10 +38,10 @@ extern CGFloat const RNSVG_DEFAULT_FONT_SIZE;
  * RNSVGSvgView which ownes current RNSVGNode
  */
 @property (nonatomic, readonly, weak) RNSVGSvgView *svgView;
+@property (nonatomic, readonly, weak) RNSVGGroup *textRoot;
 
 - (void)invalidate;
 
-- (RNSVGGroup *)getTextRoot;
 - (RNSVGGroup *)getParentTextRoot;
 
 - (void)renderTo:(CGContextRef)context;

--- a/ios/RNSVGNode.m
+++ b/ios/RNSVGNode.m
@@ -12,13 +12,16 @@
 #import "RNSVGGroup.h"
 #import "RNSVGGlyphContext.h"
 
+@interface RNSVGNode()
+@property (nonatomic, readwrite, weak) RNSVGSvgView *svgView;
+@end
+
 @implementation RNSVGNode
 {
     RNSVGGroup *_textRoot;
     RNSVGGlyphContext *glyphContext;
     BOOL _transparent;
     CGPathRef _cachedClipPath;
-    RNSVGSvgView *_svgView;
 }
 
 CGFloat const RNSVG_M_SQRT1_2l = 0.707106781186547524400844362104849039;
@@ -173,7 +176,7 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
 {
     if (self.clipPath) {
         CGPathRelease(_cachedClipPath);
-        _cachedClipPath = CGPathRetain([[[self getSvgView] getDefinedClipPath:self.clipPath] getPath:context]);
+        _cachedClipPath = CGPathRetain([[self.svgView getDefinedClipPath:self.clipPath] getPath:context]);
     }
 
     return [self getClipPath];
@@ -218,7 +221,7 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
     return nil;
 }
 
-- (RNSVGSvgView *)getSvgView
+- (RNSVGSvgView *)svgView
 {
     if (_svgView) {
         return _svgView;
@@ -229,8 +232,7 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
     if ([parent class] == [RNSVGSvgView class]) {
         _svgView = parent;
     } else if ([parent isKindOfClass:[RNSVGNode class]]) {
-        RNSVGNode *node = parent;
-        _svgView = [node getSvgView];
+        _svgView = ((RNSVGNode *)parent).svgView;
     } else {
         RCTLogError(@"RNSVG: %@ should be descendant of a SvgViewShadow.", NSStringFromClass(self.class));
     }
@@ -275,7 +277,7 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
     RNSVGGroup * root = [self getTextRoot];
     RNSVGGlyphContext * gc = [root getGlyphContext];
     if (root == nil || gc == nil) {
-        return CGRectGetWidth([[self getSvgView] getContextBounds]);
+        return CGRectGetWidth([self.svgView getContextBounds]);
     } else {
         return [gc getWidth];
     }
@@ -286,7 +288,7 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
     RNSVGGroup * root = [self getTextRoot];
     RNSVGGlyphContext * gc = [root getGlyphContext];
     if (root == nil || gc == nil) {
-        return CGRectGetHeight([[self getSvgView] getContextBounds]);
+        return CGRectGetHeight([self.svgView getContextBounds]);
     } else {
         return [gc getHeight];
     }
@@ -294,19 +296,19 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
 
 - (CGFloat)getContextLeft
 {
-    return CGRectGetMinX([[self getSvgView] getContextBounds]);
+    return CGRectGetMinX([self.svgView getContextBounds]);
 }
 
 - (CGFloat)getContextTop
 {
-    return CGRectGetMinY([[self getSvgView] getContextBounds]);
+    return CGRectGetMinY([self.svgView getContextBounds]);
 }
 
 - (void)parseReference
 {
     if (self.name) {
-        RNSVGSvgView* svg = [self getSvgView];
-        [svg defineTemplate:self templateName:self.name];
+        typeof(self) __weak weakSelf = self;
+        [self.svgView defineTemplate:weakSelf templateName:self.name];
     }
 }
 

--- a/ios/RNSVGNode.m
+++ b/ios/RNSVGNode.m
@@ -14,11 +14,11 @@
 
 @interface RNSVGNode()
 @property (nonatomic, readwrite, weak) RNSVGSvgView *svgView;
+@property (nonatomic, readwrite, weak) RNSVGGroup *textRoot;
 @end
 
 @implementation RNSVGNode
 {
-    RNSVGGroup *_textRoot;
     RNSVGGlyphContext *glyphContext;
     BOOL _transparent;
     CGPathRef _cachedClipPath;
@@ -59,23 +59,25 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
     [container invalidate];
 }
 
-- (RNSVGGroup *)getTextRoot
+- (RNSVGGroup *)textRoot
 {
+    if (_textRoot) {
+        return _textRoot;
+    }
+    
     RNSVGNode* node = self;
-    if (_textRoot == nil) {
-        while (node != nil) {
-            if ([node isKindOfClass:[RNSVGGroup class]] && [((RNSVGGroup*) node) getGlyphContext] != nil) {
-                _textRoot = (RNSVGGroup*)node;
-                break;
-            }
-
-            UIView* parent = [node superview];
-
-            if (![node isKindOfClass:[RNSVGNode class]]) {
-                node = nil;
-            } else {
-                node = (RNSVGNode*)parent;
-            }
+    while (node != nil) {
+        if ([node isKindOfClass:[RNSVGGroup class]] && [((RNSVGGroup*) node) getGlyphContext] != nil) {
+            _textRoot = (RNSVGGroup*)node;
+            break;
+        }
+        
+        UIView* parent = [node superview];
+        
+        if (![node isKindOfClass:[RNSVGNode class]]) {
+            node = nil;
+        } else {
+            node = (RNSVGNode*)parent;
         }
     }
 
@@ -88,13 +90,13 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
     if (![parent isKindOfClass:[RNSVGGroup class]]) {
         return nil;
     } else {
-        return [parent getTextRoot];
+        return parent.textRoot;
     }
 }
 
 - (CGFloat)getFontSizeFromContext
 {
-    RNSVGGroup* root = [self getTextRoot];
+    RNSVGGroup* root = self.textRoot;
     if (root == nil) {
         return RNSVG_DEFAULT_FONT_SIZE;
     }
@@ -274,7 +276,7 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
 
 - (CGFloat)getContextWidth
 {
-    RNSVGGroup * root = [self getTextRoot];
+    RNSVGGroup * root = self.textRoot;
     RNSVGGlyphContext * gc = [root getGlyphContext];
     if (root == nil || gc == nil) {
         return CGRectGetWidth([self.svgView getContextBounds]);
@@ -285,7 +287,7 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
 
 - (CGFloat)getContextHeight
 {
-    RNSVGGroup * root = [self getTextRoot];
+    RNSVGGroup * root = self.textRoot;
     RNSVGGlyphContext * gc = [root getGlyphContext];
     if (root == nil || gc == nil) {
         return CGRectGetHeight([self.svgView getContextBounds]);

--- a/ios/RNSVGRenderable.m
+++ b/ios/RNSVGRenderable.m
@@ -202,7 +202,7 @@
             CGContextClip(context);
             [self.fill paint:context
                      opacity:self.fillOpacity
-                     painter:[[self getSvgView] getDefinedPainter:self.fill.brushRef]
+                     painter:[self.svgView getDefinedPainter:self.fill.brushRef]
              ];
             CGContextRestoreGState(context);
 
@@ -247,7 +247,7 @@
 
             [self.stroke paint:context
                        opacity:self.strokeOpacity
-                       painter:[[self getSvgView] getDefinedPainter:self.stroke.brushRef]
+                       painter:[self.svgView getDefinedPainter:self.stroke.brushRef]
              ];
             return;
         }

--- a/ios/Text/RNSVGTSpan.m
+++ b/ios/Text/RNSVGTSpan.m
@@ -96,7 +96,7 @@ static double RNSVGTSpan_radToDeg = 180 / M_PI;
     // Create a dictionary for this font
     CTFontRef fontRef = [self getFontFromContext];
     CGMutablePathRef path = CGPathCreateMutable();
-    RNSVGGlyphContext* gc = [[self getTextRoot] getGlyphContext];
+    RNSVGGlyphContext* gc = [self.textRoot getGlyphContext];
     RNSVGFontData* font = [gc getFont];
     NSUInteger n = str.length;
     /*

--- a/ios/Text/RNSVGTSpan.m
+++ b/ios/Text/RNSVGTSpan.m
@@ -509,8 +509,8 @@ static double RNSVGTSpan_radToDeg = 180 / M_PI;
     double top = ascenderHeight;
     double totalHeight = top + bottom;
     double baselineShift = 0;
-    NSString *baselineShiftString = [self getBaselineShift];
-    enum RNSVGAlignmentBaseline baseline = RNSVGAlignmentBaselineFromString([self getAlignmentBaseline]);
+    NSString *baselineShiftString = self.baselineShift;
+    enum RNSVGAlignmentBaseline baseline = RNSVGAlignmentBaselineFromString(self.alignmentBaseline);
     if (baseline != RNSVGAlignmentBaselineBaseline) {
         // TODO alignment-baseline, test / verify behavior
         // TODO get per glyph baselines from font baseline table, for high-precision alignment

--- a/ios/Text/RNSVGText.h
+++ b/ios/Text/RNSVGText.h
@@ -24,7 +24,5 @@
 - (void)releaseCachedPath;
 - (CGPathRef)getGroupPath:(CGContextRef)context;
 - (CTFontRef)getFontFromContext;
-- (NSString*) getAlignmentBaseline;
-- (NSString*) getBaselineShift;
 
 @end

--- a/ios/Text/RNSVGText.m
+++ b/ios/Text/RNSVGText.m
@@ -90,52 +90,54 @@
     return root;
 }
 
-- (NSString*) getAlignmentBaseline
+- (NSString *)alignmentBaseline
 {
-    if (self.alignmentBaseline != nil) {
-        return self.alignmentBaseline;
+    if (_alignmentBaseline != nil) {
+        return _alignmentBaseline;
     }
-    UIView* parent = [self superview];
+    
+    UIView* parent = self.superview;
     while (parent != nil) {
         if ([parent isKindOfClass:[RNSVGText class]]) {
             RNSVGText* node = (RNSVGText*)parent;
             NSString* baseline = node.alignmentBaseline;
             if (baseline != nil) {
-                self.alignmentBaseline = baseline;
+                _alignmentBaseline = baseline;
                 return baseline;
             }
         }
         parent = [parent superview];
     }
-    if (self.alignmentBaseline == nil) {
-        self.alignmentBaseline = RNSVGAlignmentBaselineStrings[0];
+    
+    if (_alignmentBaseline == nil) {
+        _alignmentBaseline = RNSVGAlignmentBaselineStrings[0];
     }
-    return self.alignmentBaseline;
+    return _alignmentBaseline;
 }
 
-- (NSString*) getBaselineShift
+- (NSString *)baselineShift
 {
-    if (self.baselineShift != nil) {
-        return self.baselineShift;
+    if (_baselineShift != nil) {
+        return _baselineShift;
     }
-    if (self.baselineShift == nil) {
-        UIView* parent = [self superview];
-        while (parent != nil) {
-            if ([parent isKindOfClass:[RNSVGText class]]) {
-                RNSVGText* node = (RNSVGText*)parent;
-                NSString* baselineShift = node.baselineShift;
-                if (baselineShift != nil) {
-                    self.baselineShift = baselineShift;
-                    return baselineShift;
-                }
+    
+    UIView* parent = [self superview];
+    while (parent != nil) {
+        if ([parent isKindOfClass:[RNSVGText class]]) {
+            RNSVGText* node = (RNSVGText*)parent;
+            NSString* baselineShift = node.baselineShift;
+            if (baselineShift != nil) {
+                _baselineShift = baselineShift;
+                return baselineShift;
             }
-            parent = [parent superview];
         }
+        parent = [parent superview];
     }
-    if (self.baselineShift == nil) {
-        self.baselineShift = @"";
-    }
-    return self.baselineShift;
+    
+    // set default value
+    _baselineShift = @"";
+    
+    return _baselineShift;
 }
 
 - (RNSVGGlyphContext *)getGlyphContext

--- a/ios/Text/RNSVGText.m
+++ b/ios/Text/RNSVGText.m
@@ -15,7 +15,6 @@
 
 @implementation RNSVGText
 {
-    RNSVGText *_textRoot;
     RNSVGGlyphContext *_glyphContext;
 }
 
@@ -76,20 +75,19 @@
     [self popGlyphContext];
 }
 
-- (RNSVGText *)getTextRoot
+// TODO: Optimisation required
+- (RNSVGText *)textRoot
 {
-    if (!_textRoot) {
-        _textRoot = self;
-        while (_textRoot && [_textRoot class] != [RNSVGText class]) {
-            if (![_textRoot isKindOfClass:[RNSVGText class]]) {
-                //todo: throw exception here
-                break;
-            }
-            _textRoot = (RNSVGText*)[_textRoot superview];
+    RNSVGText *root = self;
+    while (root && [root class] != [RNSVGText class]) {
+        if (![root isKindOfClass:[RNSVGText class]]) {
+            //todo: throw exception here
+            break;
         }
+        root = (RNSVGText*)[root superview];
     }
 
-    return _textRoot;
+    return root;
 }
 
 - (NSString*) getAlignmentBaseline
@@ -147,23 +145,23 @@
 
 - (void)pushGlyphContext
 {
-    [[[self getTextRoot] getGlyphContext] pushContext:self
-                                                              font:self.font
-                                                                 x:self.positionX
-                                                                 y:self.positionY
-                                                            deltaX:self.deltaX
-                                                            deltaY:self.deltaY
-                                                            rotate:self.rotate];
+    [[self.textRoot getGlyphContext] pushContext:self
+                                            font:self.font
+                                               x:self.positionX
+                                               y:self.positionY
+                                          deltaX:self.deltaX
+                                          deltaY:self.deltaY
+                                          rotate:self.rotate];
 }
 
 - (void)popGlyphContext
 {
-    [[[self getTextRoot] getGlyphContext] popContext];
+    [[self.textRoot getGlyphContext] popContext];
 }
 
 - (CTFontRef)getFontFromContext
 {
-    return [[[self getTextRoot] getGlyphContext] getGlyphFont];
+    return [[self.textRoot getGlyphContext] getGlyphFont];
 }
 
 @end

--- a/ios/Text/RNSVGTextPath.m
+++ b/ios/Text/RNSVGTextPath.m
@@ -114,8 +114,7 @@ void RNSVGPerformanceBezier_addLine(CGPoint *last, const CGPoint *next, NSMutabl
 
 - (void)getPathLength:(CGFloat*)lengthP lineCount:(NSUInteger*)lineCountP lengths:(NSArray* __strong *)lengthsP lines:(NSArray* __strong *)linesP isClosed:(BOOL*)isClosedP
 {
-    RNSVGSvgView *svg = [self getSvgView];
-    RNSVGNode *template = [svg getDefinedTemplate:self.href];
+    RNSVGNode *template = [self.svgView getDefinedTemplate:self.href];
     CGPathRef path = [template getPath:nil];
 
     if (_path != path) {


### PR DESCRIPTION
Fix for the https://github.com/react-native-community/react-native-svg/issues/278.

The problem was in a few retain cycles, that kept objects in the memory even if the view has been removed from the stack. I hope that I've found all of them... Tested it with the images that we use in the app (some are simple, some are pretty complex), seems good now: memory is cleaned up. Of course, there are few Managers that are saved - but they are small and as I understand - for optimisation purpose. And they are not re-created each time svg is rendered.

Please, check out the PR.