### PR TITLE
Fix issue where Svg never draws if mounted while parent is hidden

### DIFF
--- a/ios/Elements/RNSVGSvgView.m
+++ b/ios/Elements/RNSVGSvgView.m
@@ -20,6 +20,16 @@
     CGAffineTransform _viewBoxTransform;
 }
 
+- (instancetype)initWithFrame:(CGRect)frame
+{
+  if (self = [super initWithFrame:frame]) {
+    // This is necessary to ensure that [self setNeedsDisplay] actually triggers
+    // a redraw when our parent transitions between hidden and visible.
+    self.contentMode = UIViewContentModeRedraw;
+  }
+  return self;
+}
+
 - (void)insertReactSubview:(UIView *)subview atIndex:(NSInteger)atIndex
 {
     [super insertReactSubview:subview atIndex:atIndex];


### PR DESCRIPTION
This is a bit of an obscure bug that occurs when using `display: 'none'` to hide layers on iOS.

I've created an Expo Snack that neatly reproduces the problem here: https://snack.expo.io/S1HhgMdKG

The repro steps are included in the snack, but essentially, the problem occurs when you do the following:

1. Hide a layer via `style={{display: 'none'}}`.
2. Mount an `Svg` as a child of the hidden layer.
3. Show the hidden layer by removing the above style.

**Expected behavior:** the Svg renders.
**Actual behavior:** nothing renders.

When the mounting occurs, the `RNSVGSvgView` properly invokes `setNeedsDisplay`; however, because it's situated in a hidden view tree, its `drawRect:` is not invoked. You would expect it to be invoked when the parent view is unhidden, but it's not.

Adding an explicit `contentMode` causes its `drawRect:` to be invoked correctly at the time that the parent is unhidden. Docs on `UIViewContentModeRedraw` are [here](https://developer.apple.com/documentation/uikit/uiviewcontentmode/uiviewcontentmoderedraw?language=objc).