### PR TITLE
Fix touch handling in groups

### DIFF
--- a/ios/Elements/RNSVGGroup.m
+++ b/ios/Elements/RNSVGGroup.m
@@ -61,6 +61,7 @@
 
         return YES;
     }];
+    [self setHitArea:[self getPath:context]];
     [self popGlyphContext];
 }
 
@@ -113,12 +114,7 @@
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
     CGPoint transformed = CGPointApplyAffineTransform(point, self.invmatrix);
-
-    UIView *hitSelf = [super hitTest:transformed withEvent:event];
-    if (hitSelf) {
-        return hitSelf;
-    }
-
+    
     CGPathRef clip = [self getClipPath];
     if (clip && !CGPathContainsPoint(clip, nil, transformed, self.clipRule == kRNSVGCGFCRuleEvenodd)) {
         return nil;
@@ -142,7 +138,12 @@
             return (node.responsible || (node != hitChild)) ? hitChild : self;
         }
     }
-
+    
+    UIView *hitSelf = [super hitTest:transformed withEvent:event];
+    if (hitSelf) {
+        return hitSelf;
+    }
+    
     return nil;
 }
 


### PR DESCRIPTION
Fixes #640 

The problem was in native code - it wasn't caching path created by internal elements.
Another thing is that implementation of `hitTest` should return "farthest descendant of the receiver in the view hierarchy" which may result in incorrect behavior when both group and internal element are set up to handle touches. If touch is landing on internal view - then it should handle touch, wrapping group otherwise.

https://developer.apple.com/documentation/uikit/uiview/1622469-hittest?language=objc



Code snippet to test:
```
import React, { Component } from "react";
import { Alert, Platform, StyleSheet, Text, View } from "react-native";
import SVG, { G, Circle } from "react-native-svg";

const showEvent = message => {
  console.log(message);
};

export default class App extends Component {
  render() {
    return (
      <View style={{ flex: 1, padding: 20 }}>
        <Text>Group</Text>
        <SVG width="200" height="200">
          <G
            onPressIn={() => {
              showEvent("group onPressIn");
            }}
            onPress={() => {
              showEvent("group onPress");
            }}
            onPressOut={() => {
              showEvent("group onPressOut");
            }}
          >
            <Circle
              cx="50"
              cy="50"
              r="40"
              stroke="green"
              strokeWidth="4"
              fill="yellow"
            />
            <Circle
              cx="80"
              cy="80"
              r="40"
              stroke="green"
              strokeWidth="4"
              fill="yellow"
            />
          </G>
        </SVG>
      </View>
    );
  }
}
```