### PR TITLE
chore(PropTypes): Fix proptypes for new RN

### DIFF
--- a/elements/Image.js
+++ b/elements/Image.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Image } from "react-native";
-import { requireNativeComponent, ImagePropTy } from "react-native";
+import { requireNativeComponent } from "react-native";
 import { ImageAttributes } from "../lib/attributes";
 import { numberProp, touchableProps, responderProps } from "../lib/props";
 import Shape from "./Shape";

--- a/elements/Image.js
+++ b/elements/Image.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Image } from "react-native";
-import { requireNativeComponent } from "react-native";
+import { requireNativeComponent, ImagePropTy } from "react-native";
 import { ImageAttributes } from "../lib/attributes";
 import { numberProp, touchableProps, responderProps } from "../lib/props";
 import Shape from "./Shape";
@@ -19,7 +19,7 @@ export default class extends Shape {
         y: numberProp,
         width: numberProp.isRequired,
         height: numberProp.isRequired,
-        href: Image.propTypes.source,
+        href: PropTypes.object,
         preserveAspectRatio: PropTypes.string
     };
 


### PR DESCRIPTION
`Image.propTypes.source` is not available in newer RN.
Change to `PropTypes.object`