### PR TITLE
drawOutput() only when Layout is != 0

### DIFF
--- a/android/src/main/java/com/horcrux/svg/SvgViewShadowNode.java
+++ b/android/src/main/java/com/horcrux/svg/SvgViewShadowNode.java
@@ -127,13 +127,18 @@ public class SvgViewShadowNode extends LayoutShadowNode {
     }
 
     private Object drawOutput() {
-        Bitmap bitmap = Bitmap.createBitmap(
-                (int) getLayoutWidth(),
-                (int) getLayoutHeight(),
-                Bitmap.Config.ARGB_8888);
+        int layoutWidth = (int) getLayoutWidth();
+        int layoutHeight = (int) getLayoutHeight();
+        if(layoutHeight != 0 && layoutWidth != 0) {
+            Bitmap bitmap = Bitmap.createBitmap(
+                    layoutWidth,
+                    layoutHeight,
+                    Bitmap.Config.ARGB_8888);
 
-        drawChildren(new Canvas(bitmap));
-        return bitmap;
+            drawChildren(new Canvas(bitmap));
+            return bitmap;
+        }
+        return null;
     }
 
     Rect getCanvasBounds() {


### PR DESCRIPTION
Sometime I need to pre-render some content. To do that, I simply render it and put a "display: none" attribute on my view. 

Doing that, I get the error : 
![screenshot_20180427-162108](https://user-images.githubusercontent.com/1107936/39423416-19b56d3e-4c72-11e8-8ba7-c22432225cb3.png)

I think this fix is just a workaround, it seems to work but I don't think this check should be done here. But I'm not able to do more on Android.

On iOS it works fine. 

version 6.3.1 