### PR TITLE
Remove 'child.type === Stop' check from extractGradient

### DIFF
--- a/lib/extract/extractGradient.js
+++ b/lib/extract/extractGradient.js
@@ -15,20 +15,14 @@ export default function(props) {
 
     const stops = {};
     Children.forEach(props.children, child => {
-        if (child.type === Stop) {
-            if (child.props.stopColor && child.props.offset) {
-                // convert percent to float.
-                let offset = percentToFloat(child.props.offset);
+        if (child.props.stopColor && child.props.offset) {
+            // convert percent to float.
+            let offset = percentToFloat(child.props.offset);
 
-                // add stop
-                //noinspection JSUnresolvedFunction
-                stops[offset] = Color(child.props.stopColor).alpha(
-                    extractOpacity(child.props.stopOpacity)
-                );
-            }
-        } else {
-            console.warn(
-                "`Gradient` elements only accept `Stop` elements as children"
+            // add stop
+            //noinspection JSUnresolvedFunction
+            stops[offset] = Color(child.props.stopColor).alpha(
+                extractOpacity(child.props.stopOpacity)
             );
         }
     });


### PR DESCRIPTION
This prevents valid composition patterns such as:

```typescript
class MyStop extends React.Component {
  render() {
    return <Stop offset="0" stopColor={"#00000000"} stopOpacity="1"/>;
  }
}

<LinearGradient>
  <MyStop />
  ...
</LinearGradient>
```

As far as I can tell, the if block directly below this check should prevent the majority of dev errors that this was trying to avoid.