### PR TITLE
Fixes android arc

### DIFF
--- a/android/src/main/java/com/horcrux/svg/PropHelper.java
+++ b/android/src/main/java/com/horcrux/svg/PropHelper.java
@@ -562,10 +562,10 @@ class PropHelper {
                 arc -= Math.PI * 2;
             }
 
-            int n = (int) Math.ceil(Math.abs(arc / (Math.PI / 2)));
+            int n = (int) Math.ceil(Math.abs(round(arc / (Math.PI / 2), 4)));
 
             float step = arc / n;
-            float k = (4 / 3) * (float) Math.tan(step / 4);
+            float k = (float) ((4 / 3.0) * Math.tan(step / 4));
 
             float x = (float) Math.cos(sa);
             float y = (float) Math.sin(sa);
@@ -581,14 +581,14 @@ class PropHelper {
                 float cp2x = x + k * y;
                 float cp2y = y - k * x;
 
-                mPath.cubicTo(
-                        (cx + xx * cp1x + yx * cp1y) * mScale,
-                        (cy + xy * cp1x + yy * cp1y) * mScale,
-                        (cx + xx * cp2x + yx * cp2y) * mScale,
-                        (cy + xy * cp2x + yy * cp2y) * mScale,
-                        (cx + xx * x + yx * y) * mScale,
-                        (cy + xy * x + yy * y) * mScale
-                    );
+                float c1x = (cx + xx * cp1x + yx * cp1y);
+                float c1y = (cy + xy * cp1x + yy * cp1y);
+                float c2x = (cx + xx * cp2x + yx * cp2y);
+                float c2y = (cy + xy * cp2x + yy * cp2y);
+                float ex = (cx + xx * x + yx * y);
+                float ey = (cy + xy * x + yy * y);
+
+                mPath.cubicTo(c1x * mScale, c1y * mScale, c2x * mScale, c2y * mScale, ex * mScale, ey * mScale);
             }
         }
 
@@ -598,6 +598,11 @@ class PropHelper {
                 mPenDownY = mPenY;
                 mPendDownSet = true;
             }
+        }
+
+        private double round(double val, int sigDig) {
+            double multiplier = Math.pow(10, sigDig);
+            return Math.round(val * multiplier) / multiplier;
         }
     }
 }


### PR DESCRIPTION
Fixes the [android arc-drawing issue #325](https://github.com/react-native-community/react-native-svg/issues/325).

Problems were:
1. the `n` calculation has to be rounded before running Math.ceil on it
1. the `(4 / 3)` in the calculation for `k` used integer division since both values are integers. It needs to use float division instead.
1. the step down from double to float during the calculation for `k` should happen at the end of the entire calculation.

This has been tested with both the Svg paths in the issue namely: 

inverse oval mask:
```
          <Svg viewbox={`0 0 270 480`} width={270} height={480}>
            <Path
              d={`
                    M 0 0 H270 V480 H0z
                    M 135 240 m -105, 0
                    a 2,3.8 0 1,0 210,0
                    a 2,3.8 0 1,0 -210,0z`}
            />
          </Svg>
```

and original partial circle
```
          <Svg width={270} height={480}>
            <Path d={`
                M118.61165235168157,295.3883476483185 A125,125 270 1 1 295.3883476483185,295.3883476483184`}
                fill="transparent"
                stroke="url(#linear-gradient)"
                strokeWidth={5}
                strokeLinecap="round" />
          </Svg>
```