### PR TITLE
fix issue that not show transparent on android

### DIFF
--- a/lib/extract/extractFill.js
+++ b/lib/extract/extractFill.js
@@ -18,7 +18,7 @@ export default function(props, styleProperties) {
 
     return {
         // default fill is black
-        fill: extractBrush(props.fill || "#000"),
+        fill: extractBrush(props.fill || "rgba(0, 0, 0, 0)"),
         fillOpacity: extractOpacity(props.fillOpacity),
         fillRule: fillRules[props.fillRule] === 0 ? 0 : 1
     };


### PR DESCRIPTION
set fill default value to transparent to fix the issue that can not show transparent background on Android. 