### PR TITLE
remove opacity from interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -267,7 +267,6 @@ export interface StopProps {
 export const Stop: React.ComponentClass<StopProps>;
 
 export interface SvgProps extends ReactNative.ViewProperties {
-  opacity?: NumberProp,
   width: NumberProp,
   height: NumberProp,
   viewBox?: string,


### PR DESCRIPTION
property is no longer needed in the extended interface