### PR TITLE
chore(Image): Update image prop type to ImageSourcePropType

### DIFF
--- a/elements/Image.js
+++ b/elements/Image.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Image } from "react-native";
-import { requireNativeComponent } from "react-native";
+import { Image, requireNativeComponent } from "react-native";
+import ImageSourcePropType from 'react-native/Libraries/Image/ImageSourcePropType';
 import { ImageAttributes } from "../lib/attributes";
 import { numberProp, touchableProps, responderProps } from "../lib/props";
 import Shape from "./Shape";
@@ -19,7 +19,7 @@ export default class extends Shape {
         y: numberProp,
         width: numberProp.isRequired,
         height: numberProp.isRequired,
-        href: Image.propTypes.source,
+        href: ImageSourcePropType,
         preserveAspectRatio: PropTypes.string
     };
 


### PR DESCRIPTION

follow-through this https://github.com/react-native-community/react-native-svg/pull/652

Since i don't have access to old repo, i re-fork this repo.

In RN 0.54 if we create prod build or set JS-DEV = false in dev settings the app will throw error because can't find `Image.propTypes.source`.