### PR TITLE
Upgrade SDK Build Tools for react-native 0.56.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,14 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 
     dependencies {
@@ -12,16 +20,14 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion safeExtGet('compileSdkVersion', 26)
     //noinspection GradleDependency
-    buildToolsVersion "23.0.1"
+    buildToolsVersion safeExtGet('buildToolsVersion', '26.0.3')
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion safeExtGet('minSdkVersion', 16)
         //noinspection OldTargetApi
-        targetSdkVersion 22
-        versionCode 1
-        versionName "1.0"
+        targetSdkVersion safeExtGet('targetSdkVersion', 26)
     }
     lintOptions {
         abortOnError false
@@ -34,6 +40,10 @@ repositories {
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
         url "$projectDir/../../../node_modules/react-native/android"
+    }
+    maven {
+        url 'https://maven.google.com/'
+        name 'Google'
     }
 }
 


### PR DESCRIPTION
Making it compatible with react-native 0.56.0

Still can use
ext {
    buildToolsVersion = "23.0.1"
    minSdkVersion = 16
    compileSdkVersion = 23
    targetSdkVersion = 23
    supportLibVersion = "23.0.1"
}
if you are using older tools.