### PR TITLE
Fix memory leak: remove references to SvgViews in onDetachedFromWindow

### DIFF
--- a/android/src/main/java/com/horcrux/svg/SvgView.java
+++ b/android/src/main/java/com/horcrux/svg/SvgView.java
@@ -72,6 +72,12 @@ public class SvgView extends ViewGroup {
         SvgViewManager.setSvgView(this);
     }
 
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        SvgViewManager.dropSvgView(this);
+    }
+
     public void setBitmap(Bitmap bitmap) {
         if (mBitmap != null) {
             mBitmap.recycle();

--- a/android/src/main/java/com/horcrux/svg/SvgViewManager.java
+++ b/android/src/main/java/com/horcrux/svg/SvgViewManager.java
@@ -51,6 +51,12 @@ class SvgViewManager extends ViewGroupManager<SvgView> {
         mTagToSvgView.put(svg.getId(), svg);
     }
 
+    static void dropSvgView(SvgView view) {
+        int tag = view.getId();
+        mTagToShadowNode.remove(tag);
+        mTagToSvgView.remove(tag);
+    }
+
     @SuppressWarnings("unused")
     static @Nullable SvgView getSvgViewByTag(int tag) {
         return mTagToSvgView.get(tag);
@@ -75,13 +81,6 @@ class SvgViewManager extends ViewGroupManager<SvgView> {
         SvgViewShadowNode node = new SvgViewShadowNode();
         node.setMeasureFunction(MEASURE_FUNCTION);
         return node;
-    }
-
-    @Override
-    public void onDropViewInstance(SvgView view) {
-        int tag = view.getId();
-        mTagToShadowNode.remove(tag);
-        mTagToSvgView.remove(tag);
     }
 
     @Override


### PR DESCRIPTION
It looks like onDropViewInstance does not get called when the entire react
instance is shut down from the native side. To gaurantee that we do not
leak memory, we need to remove the reference to the view in onDetachedFromWindow().