### PR TITLE
On Android, the strokeMinterLimit cannot be cast into Float

### DIFF
--- a/lib/extract/extractStroke.js
+++ b/lib/extract/extractStroke.js
@@ -52,6 +52,6 @@ export default function(props, styleProperties) {
         strokeDasharray: strokeDasharray,
         strokeWidth: strokeWidth,
         strokeDashoffset: strokeDasharray ? +props.strokeDashoffset || 0 : null,
-        strokeMiterlimit: props.strokeMiterlimit || 4
+        strokeMiterlimit: parseFloat(props.strokeMiterlimit) || 4
     };
 }


### PR DESCRIPTION
This PR fixes this error (parseFloat or ParseInt, both work for this fix):

![37782662_672226019795731_5905516406354477056_n](https://user-images.githubusercontent.com/24639904/43207134-d77892fa-9016-11e8-9c73-4ed93831b1b0.png)
