### PR TITLE
fixes animating clipPath in ios

### DIFF
--- a/ios/RNSVGNode.m
+++ b/ios/RNSVGNode.m
@@ -200,7 +200,7 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
 
 - (CGPathRef)getClipPath:(CGContextRef)context
 {
-    if (self.clipPath && !_cachedClipPath) {
+    if (self.clipPath) {
         _cachedClipPath = CGPathRetain([[self.svgView getDefinedClipPath:self.clipPath] getPath:context]);
     }
 


### PR DESCRIPTION
This PR implements the recently released fix for animating clipPaths in ios.

Here's the recent android-only change for reference. 
https://github.com/react-native-community/react-native-svg/commit/c16a9ed4c0f56c55e33788b4f75ef6c5532826d8