### PR TITLE
Use the React default `shadowView` to allow native animations

### DIFF
--- a/ios/ViewManagers/RNSVGNodeManager.m
+++ b/ios/ViewManagers/RNSVGNodeManager.m
@@ -24,11 +24,6 @@ RCT_EXPORT_MODULE()
     return [self node];
 }
 
-- (RCTShadowView *)shadowView
-{
-    return nil;
-}
-
 RCT_EXPORT_VIEW_PROPERTY(name, NSString)
 RCT_EXPORT_VIEW_PROPERTY(opacity, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(matrix, CGAffineTransform)


### PR DESCRIPTION
Returning a nil `shadowView` prevents natively-driven animations from working with SVG nodes, despite the fact that most SVG nodes (and node properties) support native animations.

I'm not entirely sure why `shadowNode` is set to `nil`, but removing the `nil` has been working for us in our app for 6+ months. (Perhaps it's set to `nil` to save on some memory/Yoga-layout overhead?)

I'm fairly confident that this change won't lead to regressions, but I'd be happy to hear from anybody with knowledge of the original code.