### PR TITLE
Add missing import to TSpanShadowNode.java

### DIFF
--- a/android/src/main/java/com/horcrux/svg/TSpanShadowNode.java
+++ b/android/src/main/java/com/horcrux/svg/TSpanShadowNode.java
@@ -17,6 +17,7 @@ import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.PathMeasure;
 import android.graphics.Rect;
+import android.graphics.RectF;
 import android.graphics.Typeface;
 import android.os.Build;
 


### PR DESCRIPTION
Build crashed when using `react-native@0.57.0` due to this missing import - adding the import fixed it.