### PR TITLE
Update README.md, changing dependency configuration for Android platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,25 +180,25 @@ export default class SvgExample extends React.Component {
 
 ### Common props:
 
-| Name             | Default  | Description                                                                                                                                                            |
-| ---------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| fill             | '#000'   | The fill prop refers to the color inside the shape.                                                                                                                    |
-| fillOpacity      | 1        | This prop specifies the opacity of the color or the content the current object is filled with.                                                                         |
-| fillRule         | nonzero  | The fillRule prop determines what side of a path is inside a shape, which determines how fill will paint the shape, can be `nonzero` or `evenodd`                      |
-| stroke           | 'none'   | The stroke prop controls how the outline of a shape appears.                                                                                                           |
-| strokeWidth      | 1        | The strokeWidth prop specifies the width of the outline on the current object.                                                                                         |
-| strokeOpacity    | 1        | The strokeOpacity prop specifies the opacity of the outline on the current object.                                                                                     |
-| strokeLinecap    | 'square' | The strokeLinecap prop specifies the shape to be used at the end of open subpaths when they are stroked. Can be either `'butt'`, `'square'` or `'round'`.              |
-| strokeLinejoin   | 'miter'  | The strokeLinejoin prop specifies the shape to be used at the corners of paths or basic shapes when they are stroked. Can be either `'miter'`, `'bevel'` or `'round'`. |
-| strokeDasharray  | []       | The strokeDasharray prop controls the pattern of dashes and gaps used to stroke paths.                                                                                 |
-| strokeDashoffset | null     | The strokeDashoffset prop specifies the distance into the dash pattern to start the dash.                                                                              |
-| x                | 0        | Translate distance on x-axis.                                                                                                                                          |
-| y                | 0        | Translate distance on y-axis.                                                                                                                                          |
-| rotation         | 0        | Rotation degree value on the current object.                                                                                                                           |
-| scale            | 1        | Scale value on the current object.                                                                                                                                     |
-| origin           | 0, 0     | Transform origin coordinates for the current object.                                                                                                                   |
-| originX          | 0        | Transform originX coordinates for the current object.                                                                                                                  |
-| originY          | 0        | Transform originY coordinates for the current object.                                                                                                                  |
+Name            | Default    | Description
+----------------|------------|--------------
+fill            | '#000'     | The fill prop refers to the color inside the shape.
+fillOpacity     | 1          | This prop specifies the opacity of the color or the content the current object is filled with.
+fillRule        | nonzero    | The fillRule prop determines what side of a path is inside a shape, which determines how fill will paint the shape, can be `nonzero` or `evenodd`
+stroke          | 'none'     | The stroke prop controls how the outline of a shape appears.
+strokeWidth     | 1          | The strokeWidth prop specifies the width of the outline on the current object.
+strokeOpacity   | 1          | The strokeOpacity prop specifies the opacity of the outline on the current object.
+strokeLinecap   | 'square'   | The strokeLinecap prop specifies the shape to be used at the end of open subpaths when they are stroked. Can be either `'butt'`, `'square'` or `'round'`.
+strokeLinejoin  | 'miter'    | The strokeLinejoin prop specifies the shape to be used at the corners of paths or basic shapes when they are stroked. Can be either `'miter'`, `'bevel'` or `'round'`.
+strokeDasharray | []         | The strokeDasharray prop controls the pattern of dashes and gaps used to stroke paths.
+strokeDashoffset| null       | The strokeDashoffset prop specifies the distance into the dash pattern to start the dash.
+x               | 0          | Translate distance on x-axis.
+y               | 0          | Translate distance on y-axis.
+rotation          | 0          | Rotation degree value on the current object.
+scale           | 1          | Scale value on the current object.
+origin          | 0, 0       | Transform origin coordinates for the current object.
+originX         | 0          | Transform originX coordinates for the current object.
+originY         | 0          | Transform originY coordinates for the current object.
 
 
 ### Supported elements:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@
 3. Insert the following lines inside the dependencies block in `android/app/build.gradle`:
 
 	```
-    compile project(':react-native-svg')
+    implementation project(':react-native-svg')
 	```
 
 4. Open up `android/app/src/main/java/[...]/MainApplication.java
@@ -180,25 +180,25 @@ export default class SvgExample extends React.Component {
 
 ### Common props:
 
-Name            | Default    | Description
-----------------|------------|--------------
-fill            | '#000'     | The fill prop refers to the color inside the shape.
-fillOpacity     | 1          | This prop specifies the opacity of the color or the content the current object is filled with.
-fillRule        | nonzero    | The fillRule prop determines what side of a path is inside a shape, which determines how fill will paint the shape, can be `nonzero` or `evenodd`
-stroke          | 'none'     | The stroke prop controls how the outline of a shape appears.
-strokeWidth     | 1          | The strokeWidth prop specifies the width of the outline on the current object.
-strokeOpacity   | 1          | The strokeOpacity prop specifies the opacity of the outline on the current object.
-strokeLinecap   | 'square'   | The strokeLinecap prop specifies the shape to be used at the end of open subpaths when they are stroked. Can be either `'butt'`, `'square'` or `'round'`.
-strokeLinejoin  | 'miter'    | The strokeLinejoin prop specifies the shape to be used at the corners of paths or basic shapes when they are stroked. Can be either `'miter'`, `'bevel'` or `'round'`.
-strokeDasharray | []         | The strokeDasharray prop controls the pattern of dashes and gaps used to stroke paths.
-strokeDashoffset| null       | The strokeDashoffset prop specifies the distance into the dash pattern to start the dash.
-x               | 0          | Translate distance on x-axis.
-y               | 0          | Translate distance on y-axis.
-rotation          | 0          | Rotation degree value on the current object.
-scale           | 1          | Scale value on the current object.
-origin          | 0, 0       | Transform origin coordinates for the current object.
-originX         | 0          | Transform originX coordinates for the current object.
-originY         | 0          | Transform originY coordinates for the current object.
+| Name             | Default  | Description                                                                                                                                                            |
+| ---------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| fill             | '#000'   | The fill prop refers to the color inside the shape.                                                                                                                    |
+| fillOpacity      | 1        | This prop specifies the opacity of the color or the content the current object is filled with.                                                                         |
+| fillRule         | nonzero  | The fillRule prop determines what side of a path is inside a shape, which determines how fill will paint the shape, can be `nonzero` or `evenodd`                      |
+| stroke           | 'none'   | The stroke prop controls how the outline of a shape appears.                                                                                                           |
+| strokeWidth      | 1        | The strokeWidth prop specifies the width of the outline on the current object.                                                                                         |
+| strokeOpacity    | 1        | The strokeOpacity prop specifies the opacity of the outline on the current object.                                                                                     |
+| strokeLinecap    | 'square' | The strokeLinecap prop specifies the shape to be used at the end of open subpaths when they are stroked. Can be either `'butt'`, `'square'` or `'round'`.              |
+| strokeLinejoin   | 'miter'  | The strokeLinejoin prop specifies the shape to be used at the corners of paths or basic shapes when they are stroked. Can be either `'miter'`, `'bevel'` or `'round'`. |
+| strokeDasharray  | []       | The strokeDasharray prop controls the pattern of dashes and gaps used to stroke paths.                                                                                 |
+| strokeDashoffset | null     | The strokeDashoffset prop specifies the distance into the dash pattern to start the dash.                                                                              |
+| x                | 0        | Translate distance on x-axis.                                                                                                                                          |
+| y                | 0        | Translate distance on y-axis.                                                                                                                                          |
+| rotation         | 0        | Rotation degree value on the current object.                                                                                                                           |
+| scale            | 1        | Scale value on the current object.                                                                                                                                     |
+| origin           | 0, 0     | Transform origin coordinates for the current object.                                                                                                                   |
+| originX          | 0        | Transform originX coordinates for the current object.                                                                                                                  |
+| originY          | 0        | Transform originY coordinates for the current object.                                                                                                                  |
 
 
 ### Supported elements:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,5 +49,5 @@ repositories {
 
 dependencies {
     //noinspection GradleDynamicVersion
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html