### PR TITLE
Fix require cycle between extractText.js and TSpan.js

### DIFF
--- a/elements/TSpan.js
+++ b/elements/TSpan.js
@@ -9,7 +9,7 @@ import extractTransform from "../lib/extract/extractTransform";
 import Shape from "./Shape";
 
 // TSpan elements are shadow components
-export default class extends Shape {
+export default class TSpan extends Shape {
     static displayName = "TSpan";
 
     static propTypes = textProps;
@@ -19,7 +19,7 @@ export default class extends Shape {
         if (matrix) {
             props.matrix = matrix;
         }
-        const text = _.pickBy(extractText(props, true), p => !_.isNil(p));
+        const text = _.pickBy(extractText(props, true, TSpan), p => !_.isNil(p));
         this.root.setNativeProps({
             ...props,
             ...text,
@@ -41,7 +41,7 @@ export default class extends Shape {
                     },
                     this,
                 )}
-                {...extractText(props)}
+                {...extractText(props, false, TSpan)}
             />
         );
     }

--- a/elements/Text.js
+++ b/elements/Text.js
@@ -7,6 +7,7 @@ import { TextAttributes } from "../lib/attributes";
 import extractProps from "../lib/extract/extractProps";
 import extractTransform from "../lib/extract/extractTransform";
 import Shape from "./Shape";
+import TSpan from "./TSpan";
 
 export default class extends Shape {
     static displayName = "Text";
@@ -18,7 +19,7 @@ export default class extends Shape {
         if (matrix) {
             props.matrix = matrix;
         }
-        const text = _.pickBy(extractText(props, true), p => !_.isNil(p));
+        const text = _.pickBy(extractText(props, true, TSpan), p => !_.isNil(p));
         this.root.setNativeProps({
             ...props,
             ...text,
@@ -41,7 +42,7 @@ export default class extends Shape {
                     },
                     this,
                 )}
-                {...extractText(props, true)}
+                {...extractText(props, true, TSpan)}
             />
         );
     }

--- a/elements/TextPath.js
+++ b/elements/TextPath.js
@@ -54,6 +54,7 @@ export default class extends Shape {
                             children,
                         },
                         true,
+                        TSpan,
                     )}
                 />
             );

--- a/lib/extract/extractText.js
+++ b/lib/extract/extractText.js
@@ -1,7 +1,6 @@
 import _ from "lodash";
 //noinspection JSUnresolvedVariable
 import React, { Children } from "react";
-import TSpan from "../../elements/TSpan";
 import extractLengthList from "./extractLengthList";
 
 const fontRegExp = /^\s*((?:(?:normal|bold|italic)\s+)*)(?:(\d+(?:\.\d+)?[ptexm%])*(?:\s*\/.*?)?\s+)?\s*"?([^"]*)/i;
@@ -94,7 +93,7 @@ export function extractFont(prop) {
     return _.defaults(ownedFont, font);
 }
 
-export default function(props, container) {
+export default function(props, container = false, TSpan) {
     const {
         x,
         y,


### PR DESCRIPTION
Warning
```
Require cycle: node_modules/react-native-svg/lib/extract/extractText.js -> node_modules/react-native-svg/elements/TSpan.js -> node_modules/react-native-svg/lib/extract/extractText.js

Require cycles are allowed, but can result in uninitialized values. Consider refactoring to remove the need for a cycle.
```

It's not a pretty solution, but short :)