### PR TITLE
Do not create bitmap with 0 height/width during early render.

### DIFF
--- a/android/src/main/java/com/horcrux/svg/SvgView.java
+++ b/android/src/main/java/com/horcrux/svg/SvgView.java
@@ -88,7 +88,8 @@ public class SvgView extends ReactViewGroup implements ReactCompoundView, ReactC
         if (mBitmap == null) {
             mBitmap = drawOutput();
         }
-        canvas.drawBitmap(mBitmap, 0, 0, null);
+        if (mBitmap != null)
+            canvas.drawBitmap(mBitmap, 0, 0, null);
     }
 
     @Override
@@ -213,6 +214,9 @@ public class SvgView extends ReactViewGroup implements ReactCompoundView, ReactC
             width = (float) PropHelper.fromRelative(mbbWidth, parentWidth, 0, mScale, 12);
             height = (float) PropHelper.fromRelative(mbbHeight, parentHeight, 0, mScale, 12);
             setMeasuredDimension((int)Math.ceil(width), (int)Math.ceil(height));
+        }
+        if (width == 0 || height == 0) {
+            return null;
         }
         Bitmap bitmap = Bitmap.createBitmap(
                 (int) width,


### PR DESCRIPTION
when specify background color in react-native even parent view height/width could become zero
https://github.com/react-native-community/react-native-svg/issues/823