### PR TITLE
Invalidate bitmap when view size is changed

### DIFF
--- a/android/src/main/java/com/horcrux/svg/SvgView.java
+++ b/android/src/main/java/com/horcrux/svg/SvgView.java
@@ -91,6 +91,12 @@ public class SvgView extends ReactViewGroup implements ReactCompoundView, ReactC
         if (mBitmap != null)
             canvas.drawBitmap(mBitmap, 0, 0, null);
     }
+    
+    @Override
+    protected void onSizeChanged(int w, int h, int oldw, int oldh) {
+        super.onSizeChanged(w, h, oldw, oldh);
+        this.invalidate();
+    }
 
     @Override
     public int reactTagForTouch(float touchX, float touchY) {


### PR DESCRIPTION
This change fixes a bug on Android where the SVG would not be redrawn when the `SvgView` size changes but the React props did not. 

For instance, when a `<Svg style={{ width: '100%', height: '100%' }} />` is contained within a View that can dynamically change sizes.