### PR TITLE
Update strokeDasharray docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ strokeWidth     | 1          | The strokeWidth prop specifies the width of the o
 strokeOpacity   | 1          | The strokeOpacity prop specifies the opacity of the outline on the current object.
 strokeLinecap   | 'square'   | The strokeLinecap prop specifies the shape to be used at the end of open subpaths when they are stroked. Can be either `'butt'`, `'square'` or `'round'`.
 strokeLinejoin  | 'miter'    | The strokeLinejoin prop specifies the shape to be used at the corners of paths or basic shapes when they are stroked. Can be either `'miter'`, `'bevel'` or `'round'`.
-strokeDasharray | []         | The strokeDasharray prop controls the pattern of dashes and gaps used to stroke paths.
+strokeDasharray | ''         | The strokeDasharray prop controls the pattern of dashes and gaps used to stroke paths. Example: '4 3 2 1'
 strokeDashoffset| null       | The strokeDashoffset prop specifies the distance into the dash pattern to start the dash.
 x               | 0          | Translate distance on x-axis.
 y               | 0          | Translate distance on y-axis.
@@ -268,7 +268,7 @@ originY         | 0          | Transform originY coordinates for the current obj
     <Circle cx="50" cy="50" r="30" fill="yellow" />
     <Circle cx="40" cy="40" r="4" fill="black" />
     <Circle cx="60" cy="40" r="4" fill="black" />
-    <Path d="M 40 60 A 10 10 0 0 0 60 60" stroke="black" />
+    <Path d="M 40 60 A 10 10 0 0 0 60 60" stroke="black" strokeDasharray="4 3 2 1" />
 </Svg>
 ```
 


### PR DESCRIPTION
### Why
I found that `strokeDasharray` with default value `[]` will crash on Android (iOS worked fine).
Tested on `RN v0.57.4` and `react-native-svg@8.0.8`.

Example:
```
<Path
      d={'M10 10 H 90 V 90 H 10 L 10 10'}
      fill={'transparent'}
      strokeWidth={2}
      stroke={'red'}
      strokeDasharray={[4, 3, 2, 1]}
    />
```
👉 I changed it to this and Android stop crashing.
```
<Path
      d={'M10 10 H 90 V 90 H 10 L 10 10'}
      fill={'transparent'}
      strokeWidth={2}
      stroke={'red'}
      strokeDasharray={'4 3 2 1'}
    />
```


Crash error:
`Error while updating property 'd' in shadow node of type: RNSVGPath`