### PR TITLE
Allow fontWeight to be a number

### DIFF
--- a/lib/extract/extractText.js
+++ b/lib/extract/extractText.js
@@ -51,7 +51,6 @@ export function extractFont(prop) {
         fontData,
         fontStyle,
         fontVariant,
-        fontWeight,
         fontStretch,
         textAnchor,
         textDecoration,
@@ -61,10 +60,11 @@ export function extractFont(prop) {
         fontVariantLigatures,
         fontFeatureSettings,
     } = props;
-    let { fontSize, fontFamily, font } = props;
+    let { fontSize, fontFamily, fontWeight, font } = props;
 
     fontFamily = extractSingleFontFamily(fontFamily);
     fontSize = fontSize ? "" + fontSize : null;
+    fontWeight = fontWeight ? "" + fontWeight : null;
 
     const ownedFont = _.pickBy(
         {


### PR DESCRIPTION
Currently passing `fontWeight` property as a number (e.g. `fontWeigeht={20}`) causes a crash. This is a problem because SVGR always turns numeric `fontWeight` values to numbers.

Always casting fontWeight property to string allows the value to be a number without causing a crash.

More info in SVGR's repo:
https://github.com/smooth-code/svgr/issues/243

@msand 