### PR TITLE
add google for build gradle repository

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 
     dependencies {
         //noinspection GradleDependency
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,6 +5,7 @@ def safeExtGet(prop, fallback) {
 buildscript {
     repositories {
         jcenter()
+        google()
         maven {
             url 'https://maven.google.com/'
             name 'Google'
@@ -37,6 +38,7 @@ android {
 repositories {
     mavenLocal()
     jcenter()
+    google()
     maven {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
         url "$projectDir/../../../node_modules/react-native/android"


### PR DESCRIPTION
This closes #868

adding google() as a build repository in `build.gradle`, as it is required for Android Gradle Plug-in 3.1.2
https://developer.android.com/studio/releases/gradle-plugin

