### PR TITLE
Fix compat with latest RN master

### DIFF
--- a/elements/Shape.js
+++ b/elements/Shape.js
@@ -6,7 +6,11 @@ class Shape extends Component {
     constructor() {
         super(...arguments);
         _.forEach(SvgTouchableMixin, (method, key) => {
-            this[key] = method.bind(this);
+            if (typeof method === 'function') {
+                this[key] = method.bind(this);
+            } else {
+                this[key] = method;
+            }
         });
         //noinspection JSUnusedGlobalSymbols
         this.state = this.touchableGetInitialState();


### PR DESCRIPTION
The code in the Shape constructor assumes that `SvgTouchableMixin` contains only functions but [this](https://github.com/facebook/react-native/blob/master/Libraries/Components/Touchable/Touchable.js#L904) was added which breaks this assumption.

This simply makes sure whatever we assign is a function before calling `.bind`.