### PR TITLE
Check for negative dimensions before calling Bitmap.createBitmap.

### DIFF
--- a/android/src/main/java/com/horcrux/svg/SvgView.java
+++ b/android/src/main/java/com/horcrux/svg/SvgView.java
@@ -234,7 +234,7 @@ public class SvgView extends ReactViewGroup implements ReactCompoundView, ReactC
             height = (float) PropHelper.fromRelative(mbbHeight, parentHeight, 0, mScale, 12);
             setMeasuredDimension((int)Math.ceil(width), (int)Math.ceil(height));
         }
-        if (width == 0 || height == 0) {
+        if (width <= 0 || height <= 0) {
             return null;
         }
         Bitmap bitmap = Bitmap.createBitmap(


### PR DESCRIPTION
During a LayoutAnimation.spring animation it's possible for the SvgView to have negative layout dimensions when used with 100% width/height. In this case, Android crashes with an exception.