### PR TITLE
[ios] Fix active filtering in hitTest to return the last (top-most) view

### DIFF
--- a/ios/Elements/RNSVGGroup.m
+++ b/ios/Elements/RNSVGGroup.m
@@ -169,7 +169,7 @@
         NSPredicate *const anyActive = [NSPredicate predicateWithFormat:@"active == TRUE"];
         NSArray *const filtered = [self.subviews filteredArrayUsingPredicate:anyActive];
         if ([filtered count] != 0) {
-            return [filtered.firstObject hitTest:transformed withEvent:event];
+            return [filtered.lastObject hitTest:transformed withEvent:event];
         }
     }
 


### PR DESCRIPTION
The filtering of `RNSVGGroup` in `hitTest:withEvent:` during the `reactTagAtPoint:` phase is returning the **first** active subviews with `active == TRUE`.

However, as the display order of subviews is reversed, the bottom-most group will be returned if there are more than one active subviews.

Assuming that there are two overlapping groups, if the top group is being clicked after the bottom group has been clicked (active), the bottom group will be returned.

Sample SVG to reproduce the problem:

```jsx
      <Svg viewBox="0 0 580 400" preserveAspectRatio="xMidYMid" height="400" width="580">
        <G id="svg_g1">
          <Rect onPressIn={callback1} id="svg_1" height="400" width="577" y="2" x="1" stroke-width="1.5" stroke="#0fffff" fill="#e2e21f"/>
        </G>
        <G id="svg_g3">
          <Rect onPressIn={callback2} id="svg_3" height="100" width="268" y="36" x="39.5" fill-opacity="null" stroke-opacity="null" stroke-width="1.5" stroke="#fff" fill="#000"/>
        </G>
      </Svg>
```

If the `#svg_1` is clicked first, the callback of `#svg_3` will not be invoked unless there is any click outside of the SVG view.

---------

This pull request fixed the issue by returning the **last** object instead of the **first** object

---------

_This issue exists since v8.0.10_
 