### PR TITLE
[ts] Fix SvgProps and ResponderProps interfaces.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -80,7 +80,7 @@ export interface TouchableProps {
 }
 
 export interface ResponderProps extends ReactNative.GestureResponderHandlers {
-  pointerEvents?: (event: any) => any,
+  pointerEvents?: "box-none" | "none" | "box-only" | "auto",
 }
 
 // rgba values inside range 0 to 1 inclusive

--- a/index.d.ts
+++ b/index.d.ts
@@ -306,7 +306,7 @@ export interface StopProps {
 }
 export const Stop: React.ComponentClass<StopProps>;
 
-export interface SvgProps extends ReactNative.ViewProperties {
+export interface SvgProps extends GProps, ReactNative.ViewProperties {
   width?: NumberProp,
   height?: NumberProp,
   viewBox?: string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -311,6 +311,8 @@ export interface SvgProps extends GProps, ReactNative.ViewProperties {
   height?: NumberProp,
   viewBox?: string,
   preserveAspectRatio?: string,
+  color?: int32ARGBColor | rgbaArray | string,
+  title?: string,
 }
 
 // Svg is both regular and default exported


### PR DESCRIPTION
As per discussion on https://github.com/react-native-community/react-native-svg/issues/943, `<Svg>` component accepts the same props as `<G>`, so `SvgProps` should extend `GProps`.

This PR does just that, but on doing so we get the following error from TypeScript compiler:

```
Interface 'SvgProps' cannot simultaneously extend types 'GProps' and 'ViewProps'.
Named property 'pointerEvents' of types 'GProps' and 'ViewProps' are not identical.ts(2320)
```

`GProps` extends `CommonPathProps`, which extends `ResponderProps`. No problem here. The problem seems to be that `pointerEvents` on `ResponderProps` seems to have a wrong type:

```
export interface ResponderProps extends ReactNative.GestureResponderHandlers {
  pointerEvents?: (event: any) => any,
}
```

`pointerEvents` is a prop of `ReactNative.ViewProps` as well, but with a different type:

`pointerEvents?: "box-none" | "none" | "box-only" | "auto"`

Searching for `pointerEvents` on `react-native-svg` codebase I could only find the following matches:

```
lib/extract/extractResponder.js

const pointerEvents = props.pointerEvents;
  if (pointerEvents) {
    extractedProps.pointerEvents = pointerEvents;
  }
```

Since those props are passed down to `<NativeSvgView>` and not handled anywhere else, I'm assuming that it ends up being handled by React Native itself somewhere, which would mean that the type of `pointerEvents` is indeed wrong, and it should be the same as the one in `ReactNative.ViewProps`. So alongside changing `SvgProps` I also changed that in this PR. Let me know if I'm missing something and that's not the case, in which case we might have another issue, i.e., a naming conflict between `ResponderProps`'s `pointerEvents` and `ReactNative.ViewProps`'s `pointerEvents`.