### PR TITLE
[Web] Added SVG web implementation from Expo

### DIFF
--- a/index.web.js
+++ b/index.web.js
@@ -1,0 +1,59 @@
+import { createElement } from 'react';
+
+function generate(componentName, tagName): any {
+  function SvgElement(props) {
+    return createElement(tagName, props, props.children);
+  }
+  SvgElement.displayName = componentName;
+  return SvgElement;
+}
+
+const types = {
+  Circle: 'circle',
+  ClipPath: 'clipPath',
+  Defs: 'defs',
+  Ellipse: 'ellipse',
+  G: 'g',
+  Image: 'image',
+  Line: 'line',
+  LinearGradient: 'linearGradient',
+  Path: 'path',
+  Polygon: 'polygon',
+  Polyline: 'polyline',
+  RadialGradient: 'radialGradient',
+  Rect: 'rect',
+  Stop: 'stop',
+  Symbol: 'symbol',
+  Text: 'text',
+  TextPath: 'textPath',
+  TSpan: 'tspan',
+  Use: 'use',
+};
+
+export const Svg = generate('Svg', 'svg');
+
+for (const [componentName, tagName] of Object.entries(types)) {
+  Svg[componentName] = generate(componentName, tagName);
+}
+
+export const Circle = Svg.Circle;
+export const ClipPath = Svg.ClipPath;
+export const Defs = Svg.Defs;
+export const Ellipse = Svg.Ellipse;
+export const G = Svg.G;
+export const Image = Svg.Image;
+export const Line = Svg.Line;
+export const LinearGradient = Svg.LinearGradient;
+export const Path = Svg.Path;
+export const Polygon = Svg.Polygon;
+export const Polyline = Svg.Polyline;
+export const RadialGradient = Svg.RadialGradient;
+export const Rect = Svg.Rect;
+export const Stop = Svg.Stop;
+export const Symbol = Svg.Symbol;
+export const Text = Svg.Text;
+export const TextPath = Svg.TextPath;
+export const TSpan = Svg.TSpan;
+export const Use = Svg.Use;
+
+export default Svg;

--- a/index.web.js
+++ b/index.web.js
@@ -1,4 +1,4 @@
-import { createElement } from 'react';
+import { createElement } from 'react-native-web';
 
 function generate(componentName, tagName): any {
   function SvgElement(props) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "url": "https://github.com/react-native-community/react-native-svg"
     },
     "license": "MIT",
-    "main": "./index.js",
+    "main": "./index",
     "keywords": [
         "react-component",
         "react-native",


### PR DESCRIPTION
I've added the basic implementation of SVG for `react-native-web` that I've been using internally. I noticed that there were some other PRs and issues regarding this so I wanted to get feedback before doing anything drastic. 

# Related:

#593 
#945
#265

CC: @necolas @ide 