### PR TITLE
Update react-native-svg-transformer documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,9 +291,10 @@ export default () => (
 
 Try [react-native-svg-transformer](https://github.com/kristerkari/react-native-svg-transformer) to get compile time conversion and cached transformations.
 https://github.com/kristerkari/react-native-svg-transformer#installation-and-configuration
-https://github.com/kristerkari/react-native-svg-transformer#for-react-native-v057-or-newer
+https://github.com/kristerkari/react-native-svg-transformer#for-react-native-v057-or-newer--expo-sdk-v3100-or-newer
 
-rn-cli.config.js
+`metro.config.js`
+
 ```js
 const { getDefaultConfig } = require("metro-config");
 


### PR DESCRIPTION
- Use `metro.config.js` instead of `rn-cli.config.js`.
- React Native 0.59.x ships with `metro.config.js` file, so it will be used as the default config for Metro.
- `metro.config.js` file works on React Native 0.57 and 0.58 too.