### PR TITLE
Fix typescript error in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -102,7 +102,7 @@ export interface ClipProps {
   clipPath?: string
 }
   
-VectorEffectProps {
+interface VectorEffectProps {
   vectorEffect?: "none" | "non-scaling-stroke" | "nonScalingStroke" | "default" | "inherit" | "uri";
 }
 


### PR DESCRIPTION
When upgrading to react-native-svg 9.3.1 I got these error messages in Typescript

```
node_modules/react-native-svg/index.d.ts:105:19 - error TS1005: ';' expected.

105 VectorEffectProps {
                      ~

node_modules/react-native-svg/index.d.ts:106:16 - error TS1109: Expression expected.

106   vectorEffect?: "none" | "non-scaling-stroke" | "nonScalingStroke" | "default" | "inherit" | "uri";
                   ~


Found 2 errors.
```

It seems to me that this was caused by forgetting to add the `interface` keyword before `VectorEffectProps`.

This pr fixes that.