### PR TITLE
Added missing header to the RNSVGImage.m file to fix a build error wh…

### DIFF
--- a/ios/Elements/RNSVGImage.m
+++ b/ios/Elements/RNSVGImage.m
@@ -10,6 +10,7 @@
 #import "RCTConvert+RNSVG.h"
 #import <React/RCTImageSource.h>
 #import <React/RCTImageLoader.h>
+#import <React/RCTGIFImageDecoder.h>
 #import <React/RCTLog.h>
 #import "RNSVGViewBox.h"
 


### PR DESCRIPTION
Added missing header to the RNSVGImage.m file to fix a build error when when importing as a cocoapod. While building we received the following error: 

```
error Failed to build iOS project. We ran "xcodebuild" command but it exited with error code 65. To debug build logs further, consider building your app with Xcode.app, by opening <redacted>.xcworkspace

** BUILD FAILED **


The following build commands failed:
	CompileC /Users/rbarclay/Development/<redacted>/packages/app/ios/build/<redacted>/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/RNSVG.build/Objects-normal/x86_64/RNSVGImage.o /Users/rbarclay/Development/<redacted>/packages/app/node_modules/react-native-svg/ios/Elements/RNSVGImage.m normal x86_64 objective-c com.apple.compilers.llvm.clang.1_0.compiler
(1 failure)
```

by including the above header, it resolved the problem.

our cocoapod file is configured as such: 
```
# Fix for cocapods and the new build system to not have to clean after each build when making changes to pods
install! 'cocoapods', :disable_input_output_paths => true

# Specifies the minimum deployment target for iOS. 
platform :ios, '10.0'

# Supresses warning from pod modules. Many of these we cannot fix, so why fill our warnings in xcode with them. We can
# enable warnings on a specific module if needed. Compilation errors will be shown.
inhibit_all_warnings!

target '<redacted>' do

  pod 'React', :path => '../node_modules/react-native', :modular_headers => true, :subspecs => [
    'Core',
    'CxxBridge', # Include this for RN >= 0.47
    'DevSupport', # Include this to enable In-App Devmenu if RN >= 0.43
    'RCTText',
    'RCTNetwork',
    'RCTWebSocket', # Needed for debugging
    'RCTAnimation', # Needed for FlatList and animations running on native UI thread
    'RCTLinkingIOS',
    'RCTImage',
    'RCTPushNotification',
    'RCTSettings',
    'RCTVibration',
    'RCTLinkingIOS'
  ]
  # Explicitly include Yoga if you are using RN >= 0.42.0
  pod 'yoga', :path => '../node_modules/react-native/ReactCommon/yoga'

  # Third party deps podspec link
  pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
  pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
  pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'

  pod 'RNSVG', :path => '../node_modules/react-native-svg'
  
  # The following line needs to be here, and new pods when linked with the 'react-native link [module name]` command
  # added below the line automagically
  
  # Add new pods below this line

end
```