### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,6 +2,8 @@ def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
+def gradlePluginVersion = safeExtGet('gradlePluginVersion', '3.4.0')
+
 buildscript {
     repositories {
         google()
@@ -10,7 +12,7 @@ buildscript {
 
     dependencies {
         //noinspection GradleDependency
-        classpath rootProject.ext.has('gradleBuildTools') ? rootProject.ext.get('gradleBuildTools') : 'com.android.tools.build:gradle:3.4.0'
+        classpath("com.android.tools.build:gradle:$gradlePluginVersion")
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,10 +1,7 @@
-def safeExtGet(prop, fallback) {
-    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
-}
-
-def gradlePluginVersion = safeExtGet('gradlePluginVersion', '3.4.0')
-
 buildscript {
+    ext.safeExtGet = {prop, fallback ->
+        rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+    }
     repositories {
         google()
         jcenter()
@@ -12,7 +9,7 @@ buildscript {
 
     dependencies {
         //noinspection GradleDependency
-        classpath("com.android.tools.build:gradle:$gradlePluginVersion")
+        classpath("com.android.tools.build:gradle:${safeExtGet('gradlePluginVersion', '3.4.1')}")
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,5 +45,5 @@ repositories {
 
 dependencies {
     //noinspection GradleDynamicVersion
-    implementation 'com.facebook.react:react-native:+'
+    implementation "com.facebook.react:react-native:${safeExtGet('reactnativeVersion', '+')}"
 }


### PR DESCRIPTION
read android gradle plugin version from root project

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

- Using `safeExtGet` method for reading android gradle plugin version from root project

- changing the key name from `gradleBuildTools` to `gradlePluginVersion`. I think it's better representation for the config, (value of this property is just only the version number of android gradle plugin not whole `com.android.tools.build:gradle:VERSION_NUMBER`

I tested these changes and unlike [my previous PR](https://github.com/react-native-community/react-native-svg/pull/935), the android project has been built successfully

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
