### PR TITLE
remove extra *255 in hsl conversion

### DIFF
--- a/lib/extract/extractColor.js
+++ b/lib/extract/extractColor.js
@@ -371,7 +371,7 @@ function rgbFromHslString(string) {
   const l = clamp(parseFloat(match[3]), 0, 100);
   const a = clamp(isNaN(alpha) ? 1 : alpha, 0, 1);
 
-  return hslToRgb([h, s, l, a]);
+  return [...hslToRgb([h, s, l, a]), a];
 }
 
 const hwbRegEx = /^hwb\(\s*([+-]?\d*[.]?\d+)(?:deg)?\s*,\s*([+-]?[\d.]+)%\s*,\s*([+-]?[\d.]+)%\s*(?:,\s*([+-]?[\d.]+)\s*)?\)$/;

--- a/lib/extract/extractColor.js
+++ b/lib/extract/extractColor.js
@@ -387,7 +387,7 @@ function rgbFromHwbString(string) {
   const w = clamp(parseFloat(match[2]), 0, 100);
   const b = clamp(parseFloat(match[3]), 0, 100);
   const a = clamp(isNaN(alpha) ? 1 : alpha, 0, 1);
-  return hwbToRgb([h, w, b, a]);
+  return [...hwbToRgb([h, w, b, a]), a];
 }
 
 function colorFromString(string) {

--- a/lib/extract/extractColor.js
+++ b/lib/extract/extractColor.js
@@ -172,7 +172,7 @@ function hslToRgb(hsl) {
   let val;
 
   if (s === 0) {
-    val = l * 255;
+    val = l;
     return [val, val, val];
   }
 

--- a/lib/extract/extractColor.js
+++ b/lib/extract/extractColor.js
@@ -161,10 +161,10 @@ for (const name in colorNames) {
 }
 Object.freeze(colorNames);
 
-function hslToRgb(hsl) {
-  const h = hsl[0] / 360;
-  const s = hsl[1] / 100;
-  const l = hsl[2] / 100;
+function hslToRgb(_h, _s, _l, a) {
+  const h = _h / 360;
+  const s = _s / 100;
+  const l = _l / 100;
   let t1;
   let t2;
   let t3;
@@ -173,7 +173,7 @@ function hslToRgb(hsl) {
 
   if (s === 0) {
     val = l;
-    return [val, val, val];
+    return [val, val, val, a];
   }
 
   if (l < 0.5) {
@@ -184,7 +184,7 @@ function hslToRgb(hsl) {
 
   t1 = 2 * l - t2;
 
-  rgb = [0, 0, 0];
+  rgb = [0, 0, 0, a];
   for (let i = 0; i < 3; i++) {
     t3 = h + (1 / 3) * -(i - 1);
     if (t3 < 0) {
@@ -210,10 +210,10 @@ function hslToRgb(hsl) {
   return rgb;
 }
 
-function hwbToRgb(hwb) {
-  const h = hwb[0] / 360;
-  let wh = hwb[1] / 100;
-  let bl = hwb[2] / 100;
+function hwbToRgb(_h, _w, _b, a) {
+  const h = _h / 360;
+  let wh = _w / 100;
+  let bl = _b / 100;
   const ratio = wh + bl;
   let i;
   let v;
@@ -274,7 +274,7 @@ function hwbToRgb(hwb) {
       break;
   }
 
-  return [r, g, b];
+  return [r, g, b, a];
 }
 
 function clamp(num, min, max) {
@@ -369,9 +369,8 @@ function rgbFromHslString(string) {
   const h = (parseFloat(match[1]) + 360) % 360;
   const s = clamp(parseFloat(match[2]), 0, 100);
   const l = clamp(parseFloat(match[3]), 0, 100);
-  const a = clamp(isNaN(alpha) ? 1 : alpha, 0, 1);
-
-  return [...hslToRgb([h, s, l, a]), a];
+  const a = isNaN(alpha) ? 1 : clamp(alpha, 0, 1);
+  return hslToRgb(h, s, l, a);
 }
 
 const hwbRegEx = /^hwb\(\s*([+-]?\d*[.]?\d+)(?:deg)?\s*,\s*([+-]?[\d.]+)%\s*,\s*([+-]?[\d.]+)%\s*(?:,\s*([+-]?[\d.]+)\s*)?\)$/;
@@ -386,8 +385,8 @@ function rgbFromHwbString(string) {
   const h = ((parseFloat(match[1]) % 360) + 360) % 360;
   const w = clamp(parseFloat(match[2]), 0, 100);
   const b = clamp(parseFloat(match[3]), 0, 100);
-  const a = clamp(isNaN(alpha) ? 1 : alpha, 0, 1);
-  return [...hwbToRgb([h, w, b, a]), a];
+  const a = isNaN(alpha) ? 1 : clamp(alpha, 0, 1);
+  return hwbToRgb(h, w, b, a);
 }
 
 function colorFromString(string) {


### PR DESCRIPTION
this is currently happening on lines 437-441 when converting to the
int32Color

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
when using hsl values and the saturation set to 0% the conversion from hsl -> rgb is multiplying by 255 to get an rgb value of (255, 255, 255).  This is rgb is used when creating the int32Color which then also multiplies the number by 255 again.  Removing the additional multiplication in the hslToRgb function will give consistent rgb values used to generate the int32Color.
 
<!--
Explain the **motivation** for making this change: here are some points to help you:
This should fix a bug when a number is being calculated when the saturation is set to 0%

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
None
* What is the feature? (if applicable)

* How did you implement the solution?
removed the extraneous multiplication of 255 in the hslToRgb call

* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)