### PR TITLE
Add CommonMaskProps and ClipProps to ImageProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -216,7 +216,7 @@ export interface GProps extends CommonPathProps {
 }
 export const G: React.ComponentClass<GProps>;
 
-export interface ImageProps extends ResponderProps, TouchableProps {
+export interface ImageProps extends ResponderProps, CommonMaskProps, ClipProps, TouchableProps {
   x?: NumberProp,
   y?: NumberProp,
   width?: NumberProp,


### PR DESCRIPTION
# Summary

The Image component works with the clipPath (used in one of the examples) and mask props however the TypeScript definition does no reflect this. This change simply updates the ImageProps definition.