### PR TITLE
Added missing Image clipPath property to type def.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -225,6 +225,7 @@ export interface ImageProps extends ResponderProps, CommonMaskProps, ClipProps, 
   href: ReactNative.ImageProperties['source'],
   preserveAspectRatio?: string,
   opacity?: NumberProp,
+  clipPath?: string
 }
 export const Image: React.ComponentClass<ImageProps>;
 


### PR DESCRIPTION
In the specs can be found that this property may be used, and I have verified the working;
https://github.com/react-native-community/react-native-svg#image

# Summary
Added missing Image clipPath property to Typescript type definition.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
Application using the react-native-svg package

### What are the steps to reproduce (after prerequisites)?

1. Add an Image component with clipPath to your code
2. Run typescript validation
3. Ensure you do NOT see; _Property 'clipPath' does not exist on type..._

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
