### PR TITLE
Typescript types for SvgUri and other

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ cn-doc.md
 # experimental code
 #
 experimental/
+
+# VS Code
+.vscode/

--- a/index.d.ts
+++ b/index.d.ts
@@ -101,7 +101,7 @@ export interface ClipProps {
   clipRule?: FillRule,
   clipPath?: string
 }
-  
+
 interface VectorEffectProps {
   vectorEffect?: "none" | "non-scaling-stroke" | "nonScalingStroke" | "default" | "inherit" | "uri";
 }
@@ -184,7 +184,7 @@ export interface CommonMaskProps {
   mask?: string;
 }
 
-export interface CommonPathProps extends FillProps, StrokeProps, ClipProps, TransformProps, VectorEffectProps, ResponderProps, TouchableProps, DefinitionProps, CommonMaskProps {}
+export interface CommonPathProps extends FillProps, StrokeProps, ClipProps, TransformProps, VectorEffectProps, ResponderProps, TouchableProps, DefinitionProps, CommonMaskProps { }
 
 // Element props
 export interface CircleProps extends CommonPathProps {
@@ -397,3 +397,25 @@ export interface MaskProps extends CommonPathProps {
   maskContentUnits?: TMaskUnits,
 }
 export const Mask: React.ComponentClass<MaskProps>;
+
+interface XMLElement {
+  tag: string,
+  children: XMLElement[] | void
+  props: any,
+  Tag: any // TODO: add tags?
+}
+
+export function parse(xml: string): XMLElement | null
+
+interface AstProps {
+  ast: XMLElement, override: any, children?: any
+}
+export const SvgAst: React.FunctionComponent<AstProps>
+
+interface SvgXmlProps { override?: any, xml: string }
+export const SvgXml: React.FunctionComponent<SvgXmlProps>
+export const SvgFromXml: React.ComponentClass<SvgXmlProps>
+
+interface SvgUriProps { uri: string }
+export const SvgUri: React.FunctionComponent<SvgUriProps>
+export const SvgFromUri: React.ComponentClass<SvgUriProps>

--- a/index.d.ts
+++ b/index.d.ts
@@ -407,15 +407,15 @@ interface XMLElement {
 
 export function parse(xml: string): XMLElement | null
 
-interface AstProps {
+interface AstProps extends ReactNative.ViewProps {
   ast: XMLElement, override: any, children?: any
 }
 export const SvgAst: React.FunctionComponent<AstProps>
 
-interface SvgXmlProps { override?: any, xml: string }
+interface SvgXmlProps extends ReactNative.ViewProps { override?: any, xml: string }
 export const SvgXml: React.FunctionComponent<SvgXmlProps>
 export const SvgFromXml: React.ComponentClass<SvgXmlProps>
 
-interface SvgUriProps { uri: string }
+interface SvgUriProps extends ReactNative.ViewProps { uri: string }
 export const SvgUri: React.FunctionComponent<SvgUriProps>
 export const SvgFromUri: React.ComponentClass<SvgUriProps>


### PR DESCRIPTION
# Summary

Resolves the [issue](https://github.com/react-native-community/react-native-svg/issues/1089)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
