### PR TITLE
Support for style element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2506,8 +2506,7 @@
         "atob": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-            "dev": true
+            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
         },
         "atob-lite": {
             "version": "2.0.0",
@@ -4478,6 +4477,24 @@
             "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
             "dev": true
         },
+        "css": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+            "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+            "requires": {
+                "inherits": "^2.0.3",
+                "source-map": "^0.6.1",
+                "source-map-resolve": "^0.5.2",
+                "urix": "^0.1.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                }
+            }
+        },
         "csstype": {
             "version": "2.6.7",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.7.tgz",
@@ -4556,8 +4573,7 @@
         "decode-uri-component": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-            "dev": true
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
         },
         "decompress-response": {
             "version": "3.3.0",
@@ -7283,8 +7299,7 @@
         "inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "ini": {
             "version": "1.3.5",
@@ -15368,8 +15383,7 @@
         "resolve-url": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-            "dev": true
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
         },
         "responselike": {
             "version": "1.0.2",
@@ -16389,7 +16403,6 @@
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
-            "dev": true,
             "requires": {
                 "atob": "^2.1.1",
                 "decode-uri-component": "^0.2.0",
@@ -16410,8 +16423,7 @@
         "source-map-url": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-            "dev": true
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
         },
         "spawn-error-forwarder": {
             "version": "1.0.0",
@@ -17274,8 +17286,7 @@
         "urix": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-            "dev": true
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
         },
         "url-join": {
             "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
     "react": "*",
     "react-native": ">=0.50.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "css": "^2.2.4"
+  },
   "devDependencies": {
     "@react-native-community/bob": "^0.7.0",
     "@react-native-community/eslint-config": "^0.0.5",

--- a/src/css/css.d.ts
+++ b/src/css/css.d.ts
@@ -1,0 +1,244 @@
+// Type definitions for css
+// Project: https://github.com/reworkcss/css
+// Definitions by: Ilya Verbitskiy <https://github.com/ilich>
+// Definitions: https://github.com/ilich/DefinitelyTyped
+
+// Definitions only for css/lib/parse module.
+// Content copied from @types/css/index.d.ts
+
+declare module 'css/lib/parse' {
+  /**
+   * css.parse options
+   */
+  export interface ParserOptions {
+    /** Silently fail on parse errors */
+    silent?: boolean;
+    /** The path to the file containing css. Makes errors and source maps more helpful, by letting them know where code comes from. */
+    source?: string;
+  }
+
+  /**
+   * Error thrown during parsing.
+   */
+  export interface ParserError {
+    /** The full error message with the source position. */
+    message?: string;
+    /** The error message without position. */
+    reason?: string;
+    /** The value of options.source if passed to css.parse. Otherwise undefined. */
+    filename?: string;
+    line?: number;
+    column?: number;
+    /** The portion of code that couldn't be parsed. */
+    source?: string;
+  }
+
+  // ---------------------------------------------------------------------------------
+  // AST Tree
+  // ---------------------------------------------------------------------------------
+
+  /**
+   * Information about a position in the code.
+   * The line and column numbers are 1-based: The first line is 1 and the first column of a line is 1 (not 0).
+   */
+  export interface Position {
+    line?: number;
+    column?: number;
+  }
+
+  /**
+   * Base AST Tree Node.
+   */
+  export interface Node {
+    /** The possible values are the ones listed in the Types section on https://github.com/reworkcss/css page. */
+    type?: string;
+    /** A reference to the parent node, or null if the node has no parent. */
+    parent?: Node;
+    /** Information about the position in the source string that corresponds to the node. */
+    position?: {
+      start?: Position;
+      end?: Position;
+      /** The value of options.source if passed to css.parse. Otherwise undefined. */
+      source?: string;
+      /** The full source string passed to css.parse. */
+      content?: string;
+    };
+  }
+
+  export interface Rule extends Node {
+    /** The list of selectors of the rule, split on commas. Each selector is trimmed from whitespace and comments. */
+    selectors?: Array<string>;
+    /** Array of nodes with the types declaration and comment. */
+    declarations?: Array<Declaration | Comment>;
+  }
+
+  export interface Declaration extends Node {
+    /** The property name, trimmed from whitespace and comments. May not be empty. */
+    property?: string;
+    /** The value of the property, trimmed from whitespace and comments. Empty values are allowed. */
+    value?: string;
+  }
+
+  /**
+   * A rule-level or declaration-level comment. Comments inside selectors, properties and values etc. are lost.
+   */
+  export interface Comment extends Node {
+    comment?: string;
+  }
+
+  /**
+   * The @charset at-rule.
+   */
+  export interface Charset extends Node {
+    /** The part following @charset. */
+    charset?: string;
+  }
+
+  /**
+   * The @custom-media at-rule
+   */
+  export interface CustomMedia extends Node {
+    /** The ---prefixed name. */
+    name?: string;
+    /** The part following the name. */
+    media?: string;
+  }
+
+  /**
+   * The @document at-rule.
+   */
+  export interface Document extends Node {
+    /** The part following @document. */
+    document?: string;
+    /** The vendor prefix in @document, or undefined if there is none. */
+    vendor?: string;
+    /** Array of nodes with the types rule, comment and any of the at-rule types. */
+    rules?: Array<Rule | Comment | AtRule>;
+  }
+
+  /**
+   * The @font-face at-rule.
+   */
+  export interface FontFace extends Node {
+    /** Array of nodes with the types declaration and comment. */
+    declarations?: Array<Declaration | Comment>;
+  }
+
+  /**
+   * The @host at-rule.
+   */
+  export interface Host extends Node {
+    /** Array of nodes with the types rule, comment and any of the at-rule types. */
+    rules?: Array<Rule | Comment | AtRule>;
+  }
+
+  /**
+   * The @import at-rule.
+   */
+  export interface Import extends Node {
+    /** The part following @import. */
+    import?: string;
+  }
+
+  /**
+   * The @keyframes at-rule.
+   */
+  export interface KeyFrames extends Node {
+    /** The name of the keyframes rule. */
+    name?: string;
+    /** The vendor prefix in @keyframes, or undefined if there is none. */
+    vendor?: string;
+    /** Array of nodes with the types keyframe and comment. */
+    keyframes?: Array<KeyFrame | Comment>;
+  }
+
+  export interface KeyFrame extends Node {
+    /** The list of "selectors" of the keyframe rule, split on commas. Each “selector” is trimmed from whitespace. */
+    values?: Array<string>;
+    /** Array of nodes with the types declaration and comment. */
+    declarations?: Array<Declaration | Comment>;
+  }
+
+  /**
+   * The @media at-rule.
+   */
+  export interface Media extends Node {
+    /** The part following @media. */
+    media?: string;
+    /** Array of nodes with the types rule, comment and any of the at-rule types. */
+    rules?: Array<Rule | Comment | AtRule>;
+  }
+
+  /**
+   * The @namespace at-rule.
+   */
+  export interface Namespace extends Node {
+    /** The part following @namespace. */
+    namespace?: string;
+  }
+
+  /**
+   * The @page at-rule.
+   */
+  export interface Page extends Node {
+    /** The list of selectors of the rule, split on commas. Each selector is trimmed from whitespace and comments. */
+    selectors?: Array<string>;
+    /** Array of nodes with the types declaration and comment. */
+    declarations?: Array<Declaration | Comment>;
+  }
+
+  /**
+   * The @supports at-rule.
+   */
+  export interface Supports extends Node {
+    /** The part following @supports. */
+    supports?: string;
+    /** Array of nodes with the types rule, comment and any of the at-rule types. */
+    rules?: Array<Rule | Comment | AtRule>;
+  }
+
+  /** All at-rules. */
+  export type AtRule =
+    | Charset
+    | CustomMedia
+    | Document
+    | FontFace
+    | Host
+    | Import
+    | KeyFrames
+    | Media
+    | Namespace
+    | Page
+    | Supports;
+
+  /**
+   * A collection of rules
+   */
+  export interface StyleRules {
+    /** Array of nodes with the types rule, comment and any of the at-rule types. */
+    rules: Array<Rule | Comment | AtRule>;
+    /** Array of Errors. Errors collected during parsing when option silent is true. */
+    parsingErrors?: Array<ParserError>;
+  }
+
+  /**
+   * The root node returned by css.parse.
+   */
+  export interface Stylesheet extends Node {
+    stylesheet?: StyleRules;
+  }
+
+  // ---------------------------------------------------------------------------------
+
+  /**
+   * Accepts a CSS string and returns an AST object.
+   *
+   * @param {string} code - CSS code.
+   * @param {ParserOptions} options - CSS parser options.
+   * @return {Stylesheet} AST object built using provides CSS code.
+   */
+  export default function parseCSS(
+    code: string,
+    options?: ParserOptions,
+  ): Stylesheet;
+}

--- a/src/css/index.ts
+++ b/src/css/index.ts
@@ -12,7 +12,7 @@ import parseCSS, {
   ParserError,
   Rule,
 } from 'css/lib/parse';
-import { AST } from '../xml';
+import { AST, camelCase } from '../xml';
 
 function parserErrorToString(err: ParserError): string {
   return `${err.message}`;
@@ -88,7 +88,7 @@ function applyRule(element: AST, rule: Rule) {
     const props: { [x: string]: string | undefined } = element.props;
     rule.declarations.forEach(function(decl: Declaration) {
       if (decl.property) {
-        props[decl.property] = decl.value;
+        props[camelCase(decl.property)] = decl.value;
       }
     });
   }

--- a/src/css/index.ts
+++ b/src/css/index.ts
@@ -1,0 +1,145 @@
+/// <reference path="css.d.ts"/>
+
+// We can't import from 'css' because it will add dependency to 'fs' module
+// which is not available in React Native. Instead, import directly from
+// 'css/lib/parse' and use scraped definition file 'css.d.ts' for it.
+
+import parseCSS, {
+  AtRule,
+  Comment,
+  Declaration,
+  Stylesheet,
+  ParserError,
+  Rule,
+} from 'css/lib/parse';
+import { AST } from '../xml';
+
+function parserErrorToString(err: ParserError): string {
+  return `${err.message}`;
+}
+
+function error(message: string) {
+  throw new Error(
+    `${message} (CSS). If this is valid SVG, it's probably a bug. Please raise an issue\n\n`,
+  );
+}
+
+function selectorMatches(element: AST, selector: string): boolean {
+  if (selector.length === 0) {
+    return false;
+  }
+
+  if (selector.split(/\s+/).length > 1) {
+    throw new Error(
+      `CSS selectors containing spaces are not yet supported in SVG: "${selector}"`,
+    );
+  }
+
+  if (selector[0] === '.') {
+    // class selector
+    const props: { class?: string } = element.props;
+    if (props.class) {
+      const target: string = selector.substring(1); // drop '.' prefix
+      if (props.class.split(/\s+/).find((clazz: string) => clazz === target)) {
+        return true;
+      }
+    }
+  } else {
+    // tag name selector
+    if (element.tag === selector) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function ruleMatches(element: AST, rule: Rule): boolean {
+  if (rule.selectors) {
+    for (let selector of rule.selectors) {
+      if (selectorMatches(element, selector)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+// Returns array of elements from AST tree that match given Rule.
+// Search is made recursively from given element.
+function findMatchingElements(element: AST, rule: Rule): AST[] {
+  let matching: AST[] = [];
+  if (ruleMatches(element, rule)) {
+    matching.push(element);
+  }
+
+  const children: (AST | string)[] = element.children as (AST | string)[];
+  children.forEach(function(child: AST | string) {
+    if (typeof child === 'object') {
+      matching = matching.concat(findMatchingElements(child, rule));
+    }
+  });
+
+  return matching;
+}
+
+function applyRule(element: AST, rule: Rule) {
+  if (rule.declarations) {
+    const props: { [x: string]: string | undefined } = element.props;
+    rule.declarations.forEach(function(decl: Declaration) {
+      if (decl.property) {
+        props[decl.property] = decl.value;
+      }
+    });
+  }
+}
+
+function parseStyleElement(code: string): Stylesheet {
+  // code = `apasdfupsdfau sdfj sdfaklj f${code} sdf fsd;f sdf;`;
+  const ss: Stylesheet = parseCSS(code, { silent: true }) as Stylesheet;
+  if (
+    ss.stylesheet &&
+    ss.stylesheet.parsingErrors &&
+    ss.stylesheet.parsingErrors.length > 0
+  ) {
+    const errors: string[] = ss.stylesheet.parsingErrors.map(
+      parserErrorToString,
+    );
+    const msg: string = errors.join(', ');
+    error(`Parsing error in SVG style element: ${msg}`);
+  }
+  return ss;
+}
+
+function applyStylesheet(ss: Stylesheet, root: AST) {
+  if (ss.stylesheet) {
+    ss.stylesheet.rules.forEach(function(item: Rule | Comment | AtRule) {
+      if (item.type === 'rule') {
+        const rule: Rule = item as Rule;
+        findMatchingElements(root, rule).forEach(function(element: AST) {
+          applyRule(element, rule);
+        });
+      }
+    });
+  }
+}
+
+// Finds and handles <style> elements recursively
+export default function applyCss(root: AST) {
+  function traverse(element: AST) {
+    if (element.tag === 'style' && element.children.length > 0) {
+      const stylesheet: Stylesheet = parseStyleElement(element
+        .children[0] as string);
+      applyStylesheet(stylesheet, root);
+    }
+
+    const children: (AST | string)[] = element.children as (AST | string)[];
+    children.forEach(function(child: AST | string) {
+      if (typeof child === 'object') {
+        traverse(child);
+      }
+    });
+  }
+
+  traverse(root);
+}

--- a/src/xml.tsx
+++ b/src/xml.tsx
@@ -5,6 +5,7 @@ import React, {
   useMemo,
   ComponentType,
 } from 'react';
+import applyCss from './css';
 import Rect from './elements/Rect';
 import Circle from './elements/Circle';
 import Ellipse from './elements/Ellipse';
@@ -514,6 +515,7 @@ export function parse(source: string): AST | null {
 
   if (root && typeof root === 'object') {
     const r: AST = root;
+    applyCss(r);
     const ast: (AST | string)[] = r.children as (AST | string)[];
     r.children = ast.map(astToReact);
   }

--- a/src/xml.tsx
+++ b/src/xml.tsx
@@ -171,9 +171,10 @@ export class SvgFromUri extends Component<UriProps, UriState> {
   }
 }
 
-const upperCase = (_match: string, letter: string) => letter.toUpperCase();
+export const upperCase = (_match: string, letter: string) =>
+  letter.toUpperCase();
 
-const camelCase = (phrase: string) =>
+export const camelCase = (phrase: string) =>
   phrase.replace(/[:\-]([a-z])/g, upperCase);
 
 type Styles = { [property: string]: string };


### PR DESCRIPTION
# Support for style element

* uses css module to parse `<style>` element
* Fixes #1149 

Not implemented (yet):
* Support for CSS selectors containing spaces
* CSS style sheet placed inside a CDATA block

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

SVG images containing `<style>` element.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a simulator
