### PR TITLE
Remove ts-ignore comment

### DIFF
--- a/src/lib/extract/extractTransform.ts
+++ b/src/lib/extract/extractTransform.ts
@@ -1,5 +1,4 @@
 import { append, appendTransform, identity, reset, toArray } from '../Matrix2D';
-// @ts-ignore
 import { parse } from './transform';
 import { NumberProp, TransformedProps, TransformProps } from './types';
 

--- a/src/lib/extract/transform.d.ts
+++ b/src/lib/extract/transform.d.ts
@@ -1,0 +1,1 @@
+export function parse(transform: string, options?: object): number[];


### PR DESCRIPTION
# Summary

It removes the `@ts-ignore` comment and adds types for generated `transform.js` file.

