### PR TITLE
Load Android Gradle Plugin conditionally

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,20 @@ buildscript {
     ext.safeExtGet = {prop, fallback ->
         rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
     }
-    repositories {
-        google()
-        jcenter()
-    }
-
-    dependencies {
-        //noinspection GradleDependency
-        classpath("com.android.tools.build:gradle:${safeExtGet('gradlePluginVersion', '3.4.1')}")
+    
+    // The Android Gradle plugin is only required when opening the android folder stand-alone.
+    // This avoids unnecessary downloads and potential conflicts when the library is included as a
+    // module dependency in an application project.
+    if (project == rootProject) {
+        repositories {
+            google()
+            jcenter()
+        }
+        
+        dependencies {
+            //noinspection GradleDependency
+            classpath("com.android.tools.build:gradle:3.5.1")
+        }
     }
 }
 


### PR DESCRIPTION
# Summary

This wraps the Android Gradle plugin dependency in the buildscripts section of android/build.gradle in a conditional:

```
if (project == rootProject) {
    // ... (dependency here)
}
```

The Android Gradle plugin is only required when opening the project stand-alone, not when it is included as a dependency. By doing this, the project opens correctly in Android Studio, and it can also be consumed as a native module dependency from an application project without affecting the app project (avoiding unnecessary downloads/conflicts/etc).

for more info, you can refer to [this thread](https://github.com/facebook/react-native/pull/25569) and especially [this comment.](https://github.com/facebook/react-native/pull/25569#issuecomment-532504277)

## Test Plan

Suppose you use this library on a project that has a different AGP version than this library's AGP version and the latter one is not installed on the OS. by this change, the library's AGP will not download during the build process (which it shouldn't be)

### What's required for testing (prerequisites)?

An OS that has not installed the Android Gradle Plugin version that this library already using.

### What are the steps to reproduce (after prerequisites)?

Just import this library in a project and run it on an Android emulator or a real device

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
