### PR TITLE
fix: supporting browfields implementations with a differing react root

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,12 +37,73 @@ android {
 }
 
 repositories {
-    mavenLocal()
-    google()
+    mavenCentral()
     jcenter()
-    maven {
-        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        url "$rootDir/../node_modules/react-native/android"
+    google()
+
+    def found = false
+    def defaultDir = null
+    def androidSourcesName = 'React Native sources'
+
+    if (rootProject.ext.has('reactNativeAndroidRoot')) {
+        defaultDir = rootProject.ext.get('reactNativeAndroidRoot')
+    } else {
+        defaultDir = new File(
+        projectDir,
+        '/../../../node_modules/react-native/android'
+        )
+    }
+
+    if (defaultDir.exists()) {
+        maven {
+        url defaultDir.toString()
+        name androidSourcesName
+        }
+
+        logger.info(":${project.name}:reactNativeAndroidRoot ${defaultDir.canonicalPath}")
+        found = true
+    } else {
+        def parentDir = rootProject.projectDir
+
+        1.upto(5, {
+        if (found) return true
+        parentDir = parentDir.parentFile
+
+        def androidSourcesDir = new File(
+            parentDir,
+            'node_modules/react-native'
+        )
+
+        def androidPrebuiltBinaryDir = new File(
+            parentDir,
+            'node_modules/react-native/android'
+        )
+
+        if (androidPrebuiltBinaryDir.exists()) {
+            maven {
+            url androidPrebuiltBinaryDir.toString()
+            name androidSourcesName
+            }
+
+            logger.info(":${project.name}:reactNativeAndroidRoot ${androidPrebuiltBinaryDir.canonicalPath}")
+            found = true
+        } else if (androidSourcesDir.exists()) {
+            maven {
+            url androidSourcesDir.toString()
+            name androidSourcesName
+            }
+
+            logger.info(":${project.name}:reactNativeAndroidRoot ${androidSourcesDir.canonicalPath}")
+            found = true
+        }
+        })
+    }
+
+    if (!found) {
+        throw new GradleException(
+        "${project.name}: unable to locate React Native android sources. " +
+            "Ensure you have you installed React Native as a dependency in your project and try again."
+        )
     }
 }
 


### PR DESCRIPTION
# Summary

With the change found [here](https://github.com/react-native-community/react-native-svg/commit/b4c8985b817cff2e608d0ca90cf291bde09efbb2#diff-7ae5a9093507568eabbf35c3b0665732R40) react-native-svg lost support for an implementation where any node dependencies are not located specifically at the root of the project. 

This PR borrows the gradle implementation from react-native-webview that does a better job a resolving the react root of a project and warns when this cannot be resolved.

See: https://github.com/react-native-community/react-native-webview/commit/24ec4f752cdfd29d49b0a13a0035aaea736eb641