### PR TITLE
Fix onPress handler mapping on web elements

### DIFF
--- a/src/ReactNativeSVG.web.ts
+++ b/src/ReactNativeSVG.web.ts
@@ -62,6 +62,10 @@ function prepare(props) {
     clean.ref = forwardedRef;
   }
 
+  if (props.onPress && !props.onClick){
+    clean.onClick = props.onPress;
+  }
+
   const styles: {
     fontStyle?: string;
     fontFamily?: string;


### PR DESCRIPTION
# Summary
So onPress handlers are not working on web elements like `<Path />`. I've noticed that because I am creating a graph in `react-native-svg` that works on all platforms and I needed the onPress functionality on a Path element. I've searched for some issues and saw that others are suffering the same problem:
 - [608](https://github.com/react-native-community/react-native-svg/issues/608#issuecomment-438376252)
 - [599](https://github.com/react-native-community/react-native-svg/issues/599#issuecomment-507403339) 
 - #1078

I think that this problems are related to [this line](https://github.com/necolas/react-native-web/blob/250ee3c234196fdddf6e5189c572a292566c3cb2/packages/react-native-web/src/exports/createElement/index.js#L58) that validates if the prop name is a valid prop for touchables on the web so what I did (to be as simple as possible) is to map the `onPress` handler to `onClick` handler on the web. Only impacts the web implementation.

```
obs: I don't actually know if the current behaviour is the desired one and if this is
actually a problem that should be fixed, or we won't have touchables events on path
elements.
```

## Test Plan

### What's required for testing (prerequisites)?
No prerequisites.

### What are the steps to reproduce (after prerequisites)?
Draw a simple `<Path />` element and add some onPress handler on the **web**.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Web     |    ✅     |
| Android |    N/A     |
| IOS |    N/A     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md` (N/A)
- [x] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)(N/A)
- [x] I added a sample use of the API in the example project (`example/App.js`) (N/A)
