### PR TITLE
fix: initialize PathView with empty path to support reanimated on Android

### DIFF
--- a/android/src/main/java/com/horcrux/svg/PathView.java
+++ b/android/src/main/java/com/horcrux/svg/PathView.java
@@ -24,6 +24,7 @@ class PathView extends RenderableView {
     public PathView(ReactContext reactContext) {
         super(reactContext);
         PathParser.mScale = mScale;
+        mPath = new Path();
     }
 
     @ReactProp(name = "d")


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

I was trying to animate `<Path/>` `d` attribute with `react-native-reanimated`. On iOS it worked well, but on Android, it was rising null pointer exception and the app was crashing. I found that `mPath` is null when it's trying to be used. For some reason, the `reanimated` nodes didn't manage to initialize on time, and initial `setD` was invoked after the initial render of the path. Setting default path value to an empty path solves the issue.

PS: It would be awesome to release this patch before Expo releases SDK 36, so new fixed version of `react-native-svg` will be included 🙏 

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

`react-native-reanimated` and `react-native-svg` installed in the project

### What are the steps to reproduce (after prerequisites)?

Following code used to fail on Android, works well on iOS
It's a minimal repro, so no visible path will be rendered.
```js
import React from 'react';
import {Svg, Path} from 'react-native-svg';
import Reanimated from 'react-native-reanimated';

const AnimatedPath = Reanimated.createAnimatedComponent(Path);

export default class MyExample extends React.PureComponent {
  render() {
    return (
      <Svg width={10} height={10}>
        <AnimatedPath
          d={new Reanimated.Value('')} // this used to fail on Android. Any other value fails too.
        />
      </Svg>
    );
  }
}
```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    n/a     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
