### PR TITLE
Fix middle-anchoring for lines of multiple TSpans

### DIFF
--- a/android/src/main/java/com/horcrux/svg/TSpanView.java
+++ b/android/src/main/java/com/horcrux/svg/TSpanView.java
@@ -213,6 +213,35 @@ class TSpanView extends TextView {
             return advance;
         }
 
+        ViewParent parent = getParent();
+
+        if (parent instanceof TextView) {
+            TextView textView = (TextView) parent;
+
+            for (int i = 0; i < textView.getChildCount(); i++) {
+                View child = textView.getChildAt(i);
+                if (child instanceof TSpanView) {
+                    TSpanView text = (TSpanView) child;
+                    String line = text.mContent;
+                    int length = line.length();
+
+                    if (length == 0) {
+                        continue;
+                    }
+
+                    GlyphContext gc = getTextRootGlyphContext();
+                    FontData font = gc.getFont();
+                    applyTextPropertiesToPaint(paint, font);
+
+                    applySpacingAndFeatures(paint, font);
+
+                    advance += paint.measureText(line);
+                }
+            }
+            cachedAdvance = advance;
+            return advance;
+        }
+
         String line = mContent;
         final int length = line.length();
 


### PR DESCRIPTION
# Summary

Fixes https://github.com/react-native-community/react-native-svg/issues/1205

Not really intended as the final fix for this, I only dabble in Java so I'm sure there is probably a better way to do this. Happy to make changes as required :)

## Test Plan

<img src="https://user-images.githubusercontent.com/2977095/69834208-f8325600-1230-11ea-9bcd-909793ae5a90.jpg" width="320">

### What's required for testing (prerequisites)?
Clone the repo here: https://github.com/mjmasn/TSpanIssue
Install react-native-svg from git branch / yarn link etc.

### What are the steps to reproduce (after prerequisites)?
Run the app before and after installing this patch.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    n/a (issue not tested on iOS)     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device 
- [ ] and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
