### PR TITLE
Fixes readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ import Svg, {
 } from 'react-native-svg';
 
 /* Use this if you are using Expo
-import { Svg } from 'expo';
+import * as Svg from 'react-native-svg';
 const { Circle, Rect } = Svg;
 */
 


### PR DESCRIPTION
# Summary

This line in the readme triggers a warning when running tests with jest. It should be updated to the new, correct import as promoted by expo.

It's just a readme update, no further checks and tests should be necessary. :-)