### PR TITLE
Fix NullPointerException when calling getBBox

### DIFF
--- a/android/src/main/java/com/horcrux/svg/RNSVGRenderableManager.java
+++ b/android/src/main/java/com/horcrux/svg/RNSVGRenderableManager.java
@@ -127,13 +127,13 @@ class RNSVGRenderableManager extends ReactContextBaseJavaModule {
         svg.initBounds();
 
         RectF bounds = new RectF();
-        if (fill) {
+        if (fill && svg.mFillBounds != null) {
             bounds.union(svg.mFillBounds);
         }
-        if (stroke) {
+        if (stroke && svg.mStrokeBounds != null) {
             bounds.union(svg.mStrokeBounds);
         }
-        if (markers) {
+        if (markers && svg.mMarkerBounds != null) {
             bounds.union(svg.mMarkerBounds);
         }
         if (clipped) {

--- a/android/src/main/java/com/horcrux/svg/TSpanView.java
+++ b/android/src/main/java/com/horcrux/svg/TSpanView.java
@@ -186,6 +186,10 @@ class TSpanView extends TextView {
             return mCachedPath;
         }
 
+        if (canvas == null || paint == null) {
+            return null;
+        }
+
         setupTextPath();
 
         pushGlyphContext();

--- a/android/src/main/java/com/horcrux/svg/TextView.java
+++ b/android/src/main/java/com/horcrux/svg/TextView.java
@@ -159,6 +159,9 @@ class TextView extends GroupView {
         if (mPath != null) {
             return mPath;
         }
+        if (canvas == null || paint == null) {
+            return null;
+        }
         setupGlyphContext(canvas);
         return getGroupPath(canvas, paint);
     }
@@ -210,6 +213,9 @@ class TextView extends GroupView {
     Path getGroupPath(Canvas canvas, Paint paint) {
         if (mPath != null) {
             return mPath;
+        }
+        if (canvas == null || paint == null) {
+            return null;
         }
         pushGlyphContext();
         mPath = super.getPath(canvas, paint);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
When calling `getBBox()` inside an `onLayout` callback of a `<Rect />`, we were getting a exception thrown:
NullPointerException: Attempt to read from field 'float android.graphics.RectF.left' on a null object reference.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |   n/a    |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device
- [ ] and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
