### PR TITLE
Delete regression that make every component accessible by default

### DIFF
--- a/src/ReactNativeSVG.web.ts
+++ b/src/ReactNativeSVG.web.ts
@@ -66,7 +66,6 @@ const prepare = <T extends BaseProps>(
   props = self.props,
 ) => {
   const {
-    accessible,
     translate,
     scale,
     rotation,
@@ -90,7 +89,6 @@ const prepare = <T extends BaseProps>(
   const hasTouchableProperty =
     onPress || onPressIn || onPressOut || onLongPress;
   const clean: {
-    accessible?: boolean;
     onStartShouldSetResponder?: (e: GestureResponderEvent) => boolean;
     onResponderMove?: (e: GestureResponderEvent) => void;
     onResponderGrant?: (e: GestureResponderEvent) => void;
@@ -101,7 +99,6 @@ const prepare = <T extends BaseProps>(
     style?: {};
     ref?: {};
   } = {
-    accessible: accessible !== false,
     ...(hasTouchableProperty
       ? {
           onStartShouldSetResponder:


### PR DESCRIPTION
# Summary

Fixes https://github.com/react-native-community/react-native-svg/issues/1244

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

1. Init a project with `create-react-app` and `react-native-web`
2. Add this fork of `react-native-svg` as a dependency and add a random SVG using it without setting `accessible` prop

### What are the steps to reproduce (after prerequisites)?

1. Try to focus SVG elements: it will not be possible unless you enforce `accessible={true}`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ❌     |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
