### PR TITLE
fix(android): animated stroked path with useNativeDriver: true

### DIFF
--- a/android/src/main/java/com/horcrux/svg/PathParser.java
+++ b/android/src/main/java/com/horcrux/svg/PathParser.java
@@ -33,8 +33,11 @@ class PathParser {
 
     static Path parse(String d) {
         elements = new ArrayList<>();
-        char prev_cmd = ' ';
         mPath = new Path();
+        if(d == null){
+            return mPath;
+        }
+        char prev_cmd = ' ';
         l = d.length();
         s = d;
         i = 0;

--- a/android/src/main/java/com/horcrux/svg/RenderableView.java
+++ b/android/src/main/java/com/horcrux/svg/RenderableView.java
@@ -166,9 +166,10 @@ abstract public class RenderableView extends VirtualView {
             JavaOnlyArray arr = new JavaOnlyArray();
             arr.pushInt(0);
             Matcher m = regex.matcher(strokeColors.asString());
+            int i = 0;
             while (m.find()) {
                 double parsed = Double.parseDouble(m.group());
-                arr.pushDouble(parsed);
+                arr.pushDouble(i++ < 3 ? parsed / 255 : parsed);
             }
             stroke = arr;
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

1. When animating `Path` with `d` attribute and `nativeDriver:true`, React sometimes sets `null` to the property, and it got crashed. (Still happens on `RN 0.61.4` and `react-native-svg 10.1.0`)
https://github.com/react-native-community/react-native-svg/issues/951#issuecomment-487968402
https://github.com/react-native-community/react-native-svg/issues/951#issuecomment-488825825

2. When animating `stroke` on Android, the color seems to be wrong, so I modified it by copying the implementation detail from `fill`

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Try animating stroke, and path, using `useNativeDriver:true`
https://gist.github.com/HelloCore/bafdf02644012bb47d85e828dd734e41

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
