### PR TITLE
Fix/ios crash animated path a

### DIFF
--- a/ios/Utils/RNSVGPathParser.m
+++ b/ios/Utils/RNSVGPathParser.m
@@ -40,6 +40,11 @@
 
 #define NEXT_FLOAT [self parse_list_number]
 #define NEXT_BOOL [self parse_flag]
+#define ROUND_BOOL [self round_to_bool:[self parse_list_number]]
+
+- (bool) round_to_bool: (float) number {
+    return number > 0.5;
+}
 
 - (CGPathRef)getPath
 {
@@ -163,11 +168,11 @@
                 break;
             }
             case 'a': {
-                [self arc:path rx:NEXT_FLOAT ry:NEXT_FLOAT rotation:NEXT_FLOAT outer:NEXT_BOOL clockwise:NEXT_BOOL x:NEXT_FLOAT y:NEXT_FLOAT];
+                [self arc:path rx:NEXT_FLOAT ry:NEXT_FLOAT rotation:NEXT_FLOAT outer:ROUND_BOOL clockwise:NEXT_BOOL x:NEXT_FLOAT y:NEXT_FLOAT];
                 break;
             }
             case 'A': {
-                [self arcTo:path rx:NEXT_FLOAT ry:NEXT_FLOAT rotation:NEXT_FLOAT outer:NEXT_BOOL clockwise:NEXT_BOOL x:NEXT_FLOAT y:NEXT_FLOAT];
+                [self arcTo:path rx:NEXT_FLOAT ry:NEXT_FLOAT rotation:NEXT_FLOAT outer:ROUND_BOOL clockwise:NEXT_BOOL x:NEXT_FLOAT y:NEXT_FLOAT];
                 break;
             }
             case 'z':


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
When animating `Path` using `A` with different `outer` and `nativeDriver:true`, sometimes the value of `outer` could be between 0 - 1, and it will crash.
![alt text](https://raw.githubusercontent.com/HelloCore/try_git/master/Screen%20Shot%202020-01-15%20at%2017.46.49.png)

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
https://gist.github.com/HelloCore/725c5be62d9b29b4c9b23d9c0f5e0a61

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
