### PR TITLE
[chore] Fix podspec/gitignore to work with Bazel builds (iOS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ project.xcworkspace
 .idea
 .gradle
 local.properties
-build
+build/
 
 # node.js
 #

--- a/RNSVG.podspec
+++ b/RNSVG.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.source_files     = 'ios/**/*.{h,m}'
   s.requires_arc     = true
   s.dependency         'React'
+  s.dependency         'React/RCTImage'
 end


### PR DESCRIPTION
# Summary

Hello! In order to manually link react-native-svg in an existing iOS project that uses Bazel, I have added two changes:
* Change `build` to `build/` in `.gitignore`. This doesn't add any files (it should still exclude Android gradle files), but it allows us to include our generated Bazel BUILD file when we build our app.
* Add `React/RCTImage` as a dependency to the podspec. This allows the package to build without errors (was originally getting the issue `'React/RCTImageLoader.h' file not found` as described in the README).    
