### PR TITLE
fix: removed missing unnecessary React headers import error caused by…

### DIFF
--- a/ios/Elements/RNSVGForeignObject.h
+++ b/ios/Elements/RNSVGForeignObject.h
@@ -1,7 +1,6 @@
 
 #import "RNSVGGroup.h"
 #import "RNSVGLength.h"
-#import "RCTEventDispatcher.h"
 
 @interface RNSVGForeignObject : RNSVGGroup
 


### PR DESCRIPTION
… non-framework style import

# Summary

Latest release (11.0.1) causes a compilation error by attempting to use a non framework import of `RCTEventDispatcher.h` in `RNSVGForeignObject.h`

![image](https://user-images.githubusercontent.com/116026/73220302-fa902e00-4155-11ea-8b26-75eb32a819fe.png)

This is fixable using framework style import `#import <React/RCTEventDispatcher.h>` however this is unnecessary as it is no longer used in any of the signatures, so have removed instead

## Test Plan

Built and ran locally in dependant project

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

Build fails using 11.0.1

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    n/a     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
