### PR TITLE
bumped AGP to 3.6.1 and removed buildToolsVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
         
         dependencies {
-            classpath("com.android.tools.build:gradle:3.5.3")
+            classpath("com.android.tools.build:gradle:3.6.1")
         }
     }
 }
@@ -22,8 +22,6 @@ def safeExtGet(prop, fallback) {
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
-    //noinspection GradleDependency
-    buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)


### PR DESCRIPTION
# Summary

according to [this documentation](https://developer.android.com/studio/releases/gradle-plugin#behavior_changes), it's no longer need to specify buildToolsVersion in gradle file. so I removed it.

## Test Plan

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
