### PR TITLE
bugfix: Memory leak in SVG with clip path

### DIFF
--- a/ios/RNSVGNode.m
+++ b/ios/RNSVGNode.m
@@ -327,7 +327,6 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
         }
         CGAffineTransform transform = CGAffineTransformConcat(_clipNode.matrix, _clipNode.transforms);
         _cachedClipPath = CGPathCreateCopyByTransformingPath([_clipNode getPath:context], &transform);
-        CGPathRetain(_cachedClipPath);
         if (_clipMask) {
             CGImageRelease(_clipMask);
         }


### PR DESCRIPTION
* Do not retain copy of CGPath

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR fixes a memory leak related to clip paths

When rendering SVG's containing clip paths we noticed a memory leak when cycling the app between foreground/background. Looking at the history related allocation it was recently changed from simply a CGRetain of _clipNode to a copying and transform of the same. The CGPathRetain call is still there which seems wrong as a copy will introduce the reference needed.

## Test Plan

Run code with SVG that triggers the affected code path and make sure there are no memory leaks. Make sure the Retain call did not have other obscure reasons for being left in.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
