### PR TITLE
Fix crash on double release

### DIFF
--- a/ios/Elements/RNSVGImage.m
+++ b/ios/Elements/RNSVGImage.m
@@ -40,6 +40,7 @@
     }
     _src = src;
     CGImageRelease(_image);
+    _image = nil;
     RCTImageSource *source = [RCTConvert RCTImageSource:src];
     if (source.size.width != 0 && source.size.height != 0) {
         _imageSize = source.size;


### PR DESCRIPTION
* Fix crash on double release

# Summary

Make sure image is set to nil once it has been released. This ensures
that we won't release it more than once.

Fixes #1323

## Test Plan

This repository contains an example of how to make current version crash.
https://github.com/op/svg-cat-image-boom

Point your package to `file:/.../local/path/to/react-native-svg` and run `yarn upgrade --latest --pattern react-native-svg` and you should be good to go.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
