### PR TITLE
Added exports of types to resolve editor squiggling

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -116,12 +116,12 @@ export interface ClipProps {
 
 export interface VectorEffectProps {
   vectorEffect?:
-  | 'none'
-  | 'non-scaling-stroke'
-  | 'nonScalingStroke'
-  | 'default'
-  | 'inherit'
-  | 'uri';
+    | 'none'
+    | 'non-scaling-stroke'
+    | 'nonScalingStroke'
+    | 'default'
+    | 'inherit'
+    | 'uri';
 }
 
 export interface DefinitionProps {
@@ -219,15 +219,15 @@ export interface CommonMarkerProps {
 
 export interface CommonPathProps
   extends FillProps,
-  StrokeProps,
-  ClipProps,
-  TransformProps,
-  VectorEffectProps,
-  ResponderProps,
-  TouchableProps,
-  DefinitionProps,
-  CommonMarkerProps,
-  CommonMaskProps {}
+    StrokeProps,
+    ClipProps,
+    TransformProps,
+    VectorEffectProps,
+    ResponderProps,
+    TouchableProps,
+    DefinitionProps,
+    CommonMarkerProps,
+    CommonMaskProps {}
 
 // Element props
 export interface CircleProps extends CommonPathProps {
@@ -275,9 +275,9 @@ export type ForeignObject = React.ComponentClass<ForeignObjectProps>;
 
 export interface ImageProps
   extends ResponderProps,
-  CommonMaskProps,
-  ClipProps,
-  TouchableProps {
+    CommonMaskProps,
+    ClipProps,
+    TouchableProps {
   x?: NumberProp;
   y?: NumberProp;
   width?: NumberProp;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -116,12 +116,12 @@ export interface ClipProps {
 
 export interface VectorEffectProps {
   vectorEffect?:
-    | 'none'
-    | 'non-scaling-stroke'
-    | 'nonScalingStroke'
-    | 'default'
-    | 'inherit'
-    | 'uri';
+  | 'none'
+  | 'non-scaling-stroke'
+  | 'nonScalingStroke'
+  | 'default'
+  | 'inherit'
+  | 'uri';
 }
 
 export interface DefinitionProps {
@@ -219,15 +219,15 @@ export interface CommonMarkerProps {
 
 export interface CommonPathProps
   extends FillProps,
-    StrokeProps,
-    ClipProps,
-    TransformProps,
-    VectorEffectProps,
-    ResponderProps,
-    TouchableProps,
-    DefinitionProps,
-    CommonMarkerProps,
-    CommonMaskProps {}
+  StrokeProps,
+  ClipProps,
+  TransformProps,
+  VectorEffectProps,
+  ResponderProps,
+  TouchableProps,
+  DefinitionProps,
+  CommonMarkerProps,
+  CommonMaskProps {}
 
 // Element props
 export interface CircleProps extends CommonPathProps {
@@ -256,7 +256,7 @@ export interface EllipseProps extends CommonPathProps {
   ry?: NumberProp;
 }
 export const Ellipse: React.ComponentClass<EllipseProps>;
-export type  Ellipse = React.ComponentClass<EllipseProps>;
+export type Ellipse = React.ComponentClass<EllipseProps>;
 
 export interface GProps extends CommonPathProps {
   opacity?: NumberProp;
@@ -275,9 +275,9 @@ export type ForeignObject = React.ComponentClass<ForeignObjectProps>;
 
 export interface ImageProps
   extends ResponderProps,
-    CommonMaskProps,
-    ClipProps,
-    TouchableProps {
+  CommonMaskProps,
+  ClipProps,
+  TouchableProps {
   x?: NumberProp;
   y?: NumberProp;
   width?: NumberProp;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -237,13 +237,16 @@ export interface CircleProps extends CommonPathProps {
   r?: NumberProp;
 }
 export const Circle: React.ComponentClass<CircleProps>;
+export type Circle = React.ComponentClass<CircleProps>;
 
 export interface ClipPathProps {
   id?: string;
 }
 export const ClipPath: React.ComponentClass<ClipPathProps>;
+export type ClipPath = React.ComponentClass<ClipPathProps>;
 
 export const Defs: React.ComponentClass<{}>;
+export type Defs = React.ComponentClass<{}>;
 
 export interface EllipseProps extends CommonPathProps {
   cx?: NumberProp;
@@ -253,11 +256,13 @@ export interface EllipseProps extends CommonPathProps {
   ry?: NumberProp;
 }
 export const Ellipse: React.ComponentClass<EllipseProps>;
+export type  Ellipse = React.ComponentClass<EllipseProps>;
 
 export interface GProps extends CommonPathProps {
   opacity?: NumberProp;
 }
 export const G: React.ComponentClass<GProps>;
+export type G = React.ComponentClass<GProps>;
 
 export interface ForeignObjectProps {
   x?: NumberProp;
@@ -266,6 +271,7 @@ export interface ForeignObjectProps {
   height?: NumberProp;
 }
 export const ForeignObject: React.ComponentClass<ForeignObjectProps>;
+export type ForeignObject = React.ComponentClass<ForeignObjectProps>;
 
 export interface ImageProps
   extends ResponderProps,
@@ -284,6 +290,7 @@ export interface ImageProps
   id?: string;
 }
 export const Image: React.ComponentClass<ImageProps>;
+export type Image = React.ComponentClass<ImageProps>;
 
 export interface LineProps extends CommonPathProps {
   opacity?: NumberProp;
@@ -293,6 +300,7 @@ export interface LineProps extends CommonPathProps {
   y2?: NumberProp;
 }
 export const Line: React.ComponentClass<LineProps>;
+export type Line = React.ComponentClass<LineProps>;
 
 export interface LinearGradientProps {
   x1?: NumberProp;
@@ -304,12 +312,14 @@ export interface LinearGradientProps {
   id?: string;
 }
 export const LinearGradient: React.ComponentClass<LinearGradientProps>;
+export type LinearGradient = React.ComponentClass<LinearGradientProps>;
 
 export interface PathProps extends CommonPathProps {
   d?: string;
   opacity?: NumberProp;
 }
 export const Path: React.ComponentClass<PathProps>;
+export type Path = React.ComponentClass<PathProps>;
 
 export interface PatternProps {
   id?: string;
@@ -324,18 +334,21 @@ export interface PatternProps {
   preserveAspectRatio?: string;
 }
 export const Pattern: React.ComponentClass<PatternProps>;
+export type Pattern = React.ComponentClass<PatternProps>;
 
 export interface PolygonProps extends CommonPathProps {
   opacity?: NumberProp;
   points?: string | ReadonlyArray<NumberProp>;
 }
 export const Polygon: React.ComponentClass<PolygonProps>;
+export type Polygon = React.ComponentClass<PolygonProps>;
 
 export interface PolylineProps extends CommonPathProps {
   opacity?: NumberProp;
   points?: string | ReadonlyArray<NumberProp>;
 }
 export const Polyline: React.ComponentClass<PolylineProps>;
+export type Polyline = React.ComponentClass<PolylineProps>;
 
 export interface RadialGradientProps {
   fx?: NumberProp;
@@ -350,6 +363,7 @@ export interface RadialGradientProps {
   id?: string;
 }
 export const RadialGradient: React.ComponentClass<RadialGradientProps>;
+export type RadialGradient = React.ComponentClass<RadialGradientProps>;
 
 export interface RectProps extends CommonPathProps {
   x?: NumberProp;
@@ -361,6 +375,7 @@ export interface RectProps extends CommonPathProps {
   opacity?: NumberProp;
 }
 export const Rect: React.ComponentClass<RectProps>;
+export type Rect = React.ComponentClass<RectProps>;
 
 export interface StopProps {
   stopColor?: Color;
@@ -368,6 +383,7 @@ export interface StopProps {
   offset?: NumberProp;
 }
 export const Stop: React.ComponentClass<StopProps>;
+export type Stop = React.ComponentClass<StopProps>;
 
 export interface SvgProps extends GProps, ReactNative.ViewProperties {
   width?: NumberProp;
@@ -380,6 +396,7 @@ export interface SvgProps extends GProps, ReactNative.ViewProperties {
 
 // Svg is both regular and default exported
 export const Svg: React.ComponentClass<SvgProps>;
+export type Svg = React.ComponentClass<SvgProps>;
 export default Svg;
 
 export interface SymbolProps {
@@ -389,6 +406,7 @@ export interface SymbolProps {
   opacity?: NumberProp;
 }
 export const Symbol: React.ComponentClass<SymbolProps>;
+export type Symbol = React.ComponentClass<SymbolProps>;
 
 export interface TSpanProps extends CommonPathProps, FontProps {
   x?: NumberArray;
@@ -399,6 +417,7 @@ export interface TSpanProps extends CommonPathProps, FontProps {
   inlineSize?: NumberProp;
 }
 export const TSpan: React.ComponentClass<TSpanProps>;
+export type TSpan = React.ComponentClass<TSpanProps>;
 
 export interface TextSpecificProps extends CommonPathProps, FontProps {
   alignmentBaseline?: AlignmentBaseline;
@@ -420,6 +439,7 @@ export interface TextProps extends TextSpecificProps {
   inlineSize?: NumberProp;
 }
 export const Text: React.ComponentClass<TextProps>;
+export type Text = React.ComponentClass<TextProps>;
 
 export interface TextPathProps extends TextSpecificProps {
   xlinkHref?: string;
@@ -430,6 +450,7 @@ export interface TextPathProps extends TextSpecificProps {
   midLine?: TextPathMidLine;
 }
 export const TextPath: React.ComponentClass<TextPathProps>;
+export type TextPath = React.ComponentClass<TextPathProps>;
 
 export interface UseProps extends CommonPathProps {
   xlinkHref?: string;
@@ -441,6 +462,7 @@ export interface UseProps extends CommonPathProps {
   opacity?: NumberProp;
 }
 export const Use: React.ComponentClass<UseProps>;
+export type Use = React.ComponentClass<UseProps>;
 
 export enum EMaskUnits {
   USER_SPACE_ON_USE = 'userSpaceOnUse',
@@ -462,6 +484,7 @@ export interface MaskProps extends CommonPathProps {
   maskContentUnits?: TMaskUnits;
 }
 export const Mask: React.ComponentClass<MaskProps>;
+export type Mask = React.ComponentClass<MaskProps>;
 
 export enum MarkerUnits {
   STROKE_WIDTH = 'strokeWidth',
@@ -485,6 +508,7 @@ export interface MarkerProps {
   orient?: Orient | NumberProp;
 }
 export const Marker: React.ComponentClass<MarkerProps>;
+export type Marker = React.ComponentClass<MarkerProps>;
 
 export type Styles = { [property: string]: string };
 


### PR DESCRIPTION
Some Typescript type declarations are missing and the editor complains.
See [this issue](https://github.com/react-native-community/react-native-svg/issues/1332#issuecomment-608281851) for more details.

# Summary

The issue came up by creating wrappers to the `SVG` elements while still preserving the underlying `props`. For example a Circle can be wrapped with the following declaration (the link contains the full declaration):
```
class Circle extends React.PureComponent<
  {
    id: string;
    onPress: (e: GestureResponderEvent, id: string) => void;
  } & RNSVG.Circle
>
```

The editor squiggles the word 'Circle' in `RNSVG.Circle` (after the extends).
The reason is because `Circle` is a type but was only exported as `const`.

Before:
```
export const Circle: React.ComponentClass<CircleProps>;
```
After:
```
export const Circle: React.ComponentClass<CircleProps>;
export type Circle = React.ComponentClass<CircleProps>;
```

As the fix does not change any behavior but just the Typescript declaration:
- it didn't impact on a manual test on the emulator
- no tests are provided
- no documentation is needed

## Checklist
- [X] I have tested this on a device and a simulator
- [  ] I added documentation in `README.md`
- [X ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
