### PR TITLE
SvgXml implementation for web

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2924,8 +2924,7 @@
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-      "dev": true
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
     },
     "array-ify": {
       "version": "1.0.0",
@@ -2989,8 +2988,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
       "version": "0.2.4",
@@ -5182,8 +5180,7 @@
     "core-js": {
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-      "dev": true
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
     },
     "core-js-compat": {
       "version": "3.6.4",
@@ -5226,7 +5223,6 @@
       "version": "15.6.3",
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
       "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
-      "dev": true,
       "requires": {
         "fbjs": "^0.8.9",
         "loose-envify": "^1.3.1",
@@ -5236,14 +5232,12 @@
         "core-js": {
           "version": "1.2.7",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-          "dev": true
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         },
         "fbjs": {
           "version": "0.8.17",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
           "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-          "dev": true,
           "requires": {
             "core-js": "^1.0.0",
             "isomorphic-fetch": "^2.1.1",
@@ -5280,6 +5274,16 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
       "dev": true
+    },
+    "css-in-js-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
+      "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
+      "optional": true,
+      "requires": {
+        "hyphenate-style-name": "^1.0.2",
+        "isobject": "^3.0.1"
+      }
     },
     "css-select": {
       "version": "2.1.0",
@@ -5382,6 +5386,12 @@
       "integrity": "sha512-1kbWK0hziklUHkGgiKr7xm59KwAg/K3Tp7H/8X+f58DnNCwY3pKYjOCJpIlVs125FRBukGVZdKZojC073D0IeQ==",
       "dev": true
     },
+    "debounce": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
+      "integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==",
+      "optional": true
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -5435,6 +5445,15 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
+    },
+    "deep-assign": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-3.0.0.tgz",
+      "integrity": "sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==",
+      "optional": true,
+      "requires": {
+        "is-obj": "^1.0.0"
+      }
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -5735,7 +5754,6 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "dev": true,
       "requires": {
         "iconv-lite": "~0.4.13"
       }
@@ -6547,7 +6565,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
       "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
-      "dev": true,
       "requires": {
         "core-js": "^2.4.1",
         "fbjs-css-vars": "^1.0.0",
@@ -6562,8 +6579,7 @@
     "fbjs-css-vars": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
-      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
-      "dev": true
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
     },
     "fbjs-scripts": {
       "version": "1.2.0",
@@ -7616,11 +7632,16 @@
         "ms": "^2.0.0"
       }
     },
+    "hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==",
+      "optional": true
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -7725,6 +7746,15 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
+    },
+    "inline-style-prefixer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-5.1.2.tgz",
+      "integrity": "sha512-PYUF+94gDfhy+LsQxM0g3d6Hge4l1pAqOSOiZuHWzMvQEGsbRQ/ck2WioLqrY2ZkHyPgVUXxn+hrkF7D6QUGbA==",
+      "optional": true,
+      "requires": {
+        "css-in-js-utils": "^2.0.0"
+      }
     },
     "inquirer": {
       "version": "7.0.6",
@@ -8036,8 +8066,7 @@
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-path-cwd": {
       "version": "2.2.0",
@@ -8084,8 +8113,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-string": {
       "version": "1.0.5",
@@ -8150,14 +8178,12 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
@@ -8167,7 +8193,6 @@
           "version": "1.7.3",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
           "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "dev": true,
           "requires": {
             "encoding": "^0.1.11",
             "is-stream": "^1.0.1"
@@ -8812,8 +8837,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -9452,7 +9476,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -12760,6 +12783,12 @@
         "abbrev": "1",
         "osenv": "^0.1.4"
       }
+    },
+    "normalize-css-color": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-css-color/-/normalize-css-color-1.0.2.tgz",
+      "integrity": "sha1-Apkel8zOxmI/5XOvu/Deah8+n40=",
+      "optional": true
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -16453,8 +16482,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -17370,7 +17398,6 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dev": true,
       "requires": {
         "asap": "~2.0.3"
       }
@@ -17413,7 +17440,6 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -17558,8 +17584,7 @@
     "react-is": {
       "version": "16.13.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
-      "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==",
-      "dev": true
+      "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA=="
     },
     "react-native": {
       "version": "0.61.5",
@@ -18006,6 +18031,24 @@
         }
       }
     },
+    "react-native-web": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.13.4.tgz",
+      "integrity": "sha512-SXplf0ksAeZZPvo7Gq8y/A0BcdqdJouPCmHLUQ5a9P85uMPclJXwUynvVIwl7vxP9qmg39MatOMD8A7K0neTPQ==",
+      "optional": true,
+      "requires": {
+        "array-find-index": "^1.0.2",
+        "create-react-class": "^15.6.2",
+        "debounce": "^1.2.0",
+        "deep-assign": "^3.0.0",
+        "fbjs": "^1.0.0",
+        "hyphenate-style-name": "^1.0.3",
+        "inline-style-prefixer": "^5.1.0",
+        "normalize-css-color": "^1.0.2",
+        "prop-types": "^15.6.0",
+        "react-timer-mixin": "^0.13.4"
+      }
+    },
     "react-refresh": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.2.tgz",
@@ -18035,6 +18078,12 @@
           }
         }
       }
+    },
+    "react-timer-mixin": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/react-timer-mixin/-/react-timer-mixin-0.13.4.tgz",
+      "integrity": "sha512-4+ow23tp/Tv7hBM5Az5/Be/eKKF7DIvJ09voz5LyHGQaqqz9WV8YMs31eFvcYQs7d451LSg7kDJV70XYN/Ug/Q==",
+      "optional": true
     },
     "read-pkg": {
       "version": "2.0.0",
@@ -18611,8 +18660,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "4.1.0",
@@ -19147,8 +19195,7 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "setprototypeof": {
       "version": "1.1.1",
@@ -20279,8 +20326,7 @@
     "ua-parser-js": {
       "version": "0.7.21",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
-      "dev": true
+      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
     },
     "uglify-es": {
       "version": "3.3.9",
@@ -20704,8 +20750,7 @@
     "whatwg-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
-      "dev": true
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,6 @@
   },
   "nativePackage": true,
   "optionalDependencies": {
-    "react-native-web": "^0.13.4"
+    "react-native-web": ">=0.13.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -103,5 +103,8 @@
       "@semantic-release/git"
     ]
   },
-  "nativePackage": true
+  "nativePackage": true,
+  "optionalDependencies": {
+    "react-native-web": "^0.13.4"
+  }
 }

--- a/src/ReactNativeSVG.web.ts
+++ b/src/ReactNativeSVG.web.ts
@@ -10,6 +10,8 @@ import {
 import { NumberArray, NumberProp } from './lib/extract/types';
 import SvgTouchableMixin from './lib/SvgTouchableMixin';
 import { resolve } from './lib/resolve';
+export { default as SvgXml } from './SvgXml.web';
+export { default as SvgCss } from './SvgXml.web';
 
 const createElement = cE || ucE;
 

--- a/src/SvgXml.web.tsx
+++ b/src/SvgXml.web.tsx
@@ -2,14 +2,71 @@ import React from 'react';
 import { ViewProps } from 'react-native';
 import { View, unstable_createElement } from 'react-native-web';
 import { XmlProps } from './xml';
+// rgba values inside range 0 to 1 inclusive
+// rgbaArray = [r, g, b, a]
+export type rgbaArray = ReadonlyArray<number>;
+
+// argb values inside range 0x00 to 0xff inclusive
+// int32ARGBColor = 0xaarrggbb
+export type int32ARGBColor = number;
+type NumberProp = string | number;
+type FillRule = 'evenodd' | 'nonzero';
+type Linecap = 'butt' | 'square' | 'round';
+type Linejoin = 'miter' | 'bevel' | 'round';
+type Color = int32ARGBColor | rgbaArray | string;
+type NumberArray = NumberProp[] | NumberProp;
+
 type SvgXmlProps = XmlProps &
   ViewProps & {
-    height: number | string;
-    width: number | string;
+    height: NumberProp;
+    width: NumberProp;
     viewBox?: string;
     preserveAspectRatio?: string;
-    color?: string;
+    color?: Color;
     title?: string;
+    opacity?: NumberProp;
+    fill?: Color;
+    fillOpacity?: number;
+    fillRule?: FillRule;
+    stroke?: Color;
+    strokeWidth?: NumberProp;
+    strokeOpacity?: NumberProp;
+    strokeDasharray?: ReadonlyArray<NumberProp> | NumberProp;
+    strokeDashoffset?: NumberProp;
+    strokeLinecap?: Linecap;
+    strokeLinejoin?: Linejoin;
+    strokeMiterlimit?: NumberProp;
+    clipRule?: FillRule;
+    clipPath?: string;
+    translate?: NumberArray;
+    translateX?: NumberProp;
+    translateY?: NumberProp;
+    origin?: NumberArray;
+    originX?: NumberProp;
+    originY?: NumberProp;
+    scale?: NumberArray;
+    scaleX?: NumberProp;
+    scaleY?: NumberProp;
+    skew?: NumberArray;
+    skewX?: NumberProp;
+    skewY?: NumberProp;
+    rotation?: NumberProp;
+    x?: NumberArray;
+    y?: NumberArray;
+    vectorEffect?:
+      | 'none'
+      | 'non-scaling-stroke'
+      | 'nonScalingStroke'
+      | 'default'
+      | 'inherit'
+      | 'uri';
+    pointerEvents?: 'box-none' | 'none' | 'box-only' | 'auto';
+    id?: string;
+    marker?: string;
+    markerStart?: string;
+    markerMid?: string;
+    markerEnd?: string;
+    mask?: string;
   };
 const SvgXml = React.forwardRef<HTMLOrSVGElement, SvgXmlProps>(
   ({ xml, ...props }, fowardRef) => {
@@ -30,17 +87,93 @@ const SvgXml = React.forwardRef<HTMLOrSVGElement, SvgXmlProps>(
       viewBox,
       preserveAspectRatio,
       color,
+      title,
+      opacity,
+      fill,
+      fillOpacity,
+      fillRule,
+      stroke,
+      strokeWidth,
+      strokeOpacity,
+      strokeDasharray,
+      strokeDashoffset,
+      strokeLinecap,
+      strokeLinejoin,
+      strokeMiterlimit,
+      clipRule,
+      clipPath,
+      translate,
+      translateX,
+      translateY,
+      origin,
+      originX,
+      originY,
+      scale,
+      scaleX,
+      scaleY,
+      skew,
+      skewX,
+      skewY,
+      rotation,
+      x,
+      y,
+      vectorEffect,
+      pointerEvents,
+      id,
+      marker,
+      markerStart,
+      markerMid,
+      markerEnd,
+      mask,
       // props that should be applyed to the View container
       ...containerProps
     } = props;
 
     // these props should override the xml props
     const overrideProps = {
-      height,
-      width,
+      height: '100%',
+      width: '100%',
       viewBox,
       preserveAspectRatio,
       color,
+      title,
+      opacity,
+      fill,
+      fillOpacity,
+      fillRule,
+      stroke,
+      strokeWidth,
+      strokeOpacity,
+      strokeDasharray,
+      strokeDashoffset,
+      strokeLinecap,
+      strokeLinejoin,
+      strokeMiterlimit,
+      clipRule,
+      clipPath,
+      translate,
+      translateX,
+      translateY,
+      origin,
+      originX,
+      originY,
+      scale,
+      scaleX,
+      scaleY,
+      skew,
+      skewX,
+      skewY,
+      rotation,
+      x,
+      y,
+      vectorEffect,
+      pointerEvents,
+      id,
+      marker,
+      markerStart,
+      markerMid,
+      markerEnd,
+      mask,
     };
 
     const finalProps = { ...camelAttributes, ...overrideProps };

--- a/src/SvgXml.web.tsx
+++ b/src/SvgXml.web.tsx
@@ -224,8 +224,7 @@ const SvgXml = React.forwardRef<HTMLOrSVGElement, XmlProps>(
 
     // these props should override the xml props
     const overrideProps = {
-      height: '100%',
-      width: '100%',
+      style: { width: '100%', height: '100%' },
       transform: transformArr.length ? transformArr.join(' ') : transform,
       viewBox,
       preserveAspectRatio,
@@ -254,7 +253,10 @@ const SvgXml = React.forwardRef<HTMLOrSVGElement, XmlProps>(
       mask,
     };
 
-    const finalProps = { ...camelAttributes, ...overrideProps };
+    const finalProps = {
+      ...camelAttributes,
+      ...removeUndefined(overrideProps),
+    };
     const Svg = unstable_createElement('svg', { ref: svgRef, ...finalProps });
 
     const containerDefaultStyles = {
@@ -289,15 +291,26 @@ function parseSVG(svg: string) {
   const content = svg.match(/<svg(.*)<\/svg>/ims)[1];
   const [, attrs, innerSVG] = content.match(/(.*?)>(.*)/ims);
   const attributes = [
-    ...matchAll(attrs)(/([a-z0-9]+)(=['"](.*?)['"])?[\s>]/gims),
+    ...matchAll(attrs)(/([a-z0-9]+)(=['"](.*?)['"])?/gims),
   ].map(([, key, , value]) => ({ [key]: value }));
   return { attributes, innerSVG };
 }
 
-function kebabToCamel(obj) {
+function kebabToCamel(attrs) {
   const camelObj = {};
-  Object.keys(obj).forEach(key => {
-    camelObj[key.replace(/-./g, x => x.toUpperCase()[1])] = obj[key];
+  attrs.forEach(attr => {
+    const key = Object.keys(attr)[0];
+    camelObj[key.replace(/-./g, x => x.toUpperCase()[1])] = attr[key];
   });
   return camelObj;
+}
+
+function removeUndefined(obj) {
+  const finalObj = {};
+  Object.keys(obj).forEach(key => {
+    if (obj[key] !== undefined) {
+      finalObj[key] = obj[key];
+    }
+  });
+  return finalObj;
 }

--- a/src/SvgXml.web.tsx
+++ b/src/SvgXml.web.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { ViewProps } from 'react-native';
+import { View, unstable_createElement } from 'react-native-web';
+import { XmlProps } from './xml';
+type SvgXmlProps = XmlProps &
+  ViewProps & {
+    height: number | string;
+    width: number | string;
+    viewBox?: string;
+    preserveAspectRatio?: string;
+    color?: string;
+    title?: string;
+  };
+const SvgXml = React.forwardRef<HTMLOrSVGElement, SvgXmlProps>(
+  ({ xml, ...props }) => {
+    const { attributes, innerSVG } = parseSVG(xml);
+    const camelAttributes = kebabToCamel(attributes);
+
+    const svgRef = React.createRef<SVGElement>();
+    React.useLayoutEffect(() => {
+      if (!svgRef.current) {
+        return;
+      }
+      svgRef.current.innerHTML = innerSVG;
+    }, [innerSVG, svgRef]);
+
+    const {
+      height,
+      width,
+      viewBox,
+      preserveAspectRatio,
+      color,
+      // props that should be applyed to the View container
+      ...containerProps
+    } = props;
+
+    // these props should override the xml props
+    const overrideProps = {
+      height,
+      width,
+      viewBox,
+      preserveAspectRatio,
+      color,
+    };
+
+    const finalProps = { ...camelAttributes, ...overrideProps };
+    const Svg = unstable_createElement('svg', { ref: svgRef, ...finalProps });
+    return (
+      <View {...containerProps}>
+        <Svg />
+      </View>
+    );
+  },
+);
+
+SvgXml.displayName = 'Svg';
+
+export default SvgXml;
+
+/** polyfill for Node < 12 */
+function matchAll(str) {
+  return re => {
+    const matches = [];
+    let groups;
+    while ((groups = re.exec(str))) {
+      matches.push(groups);
+    }
+    return matches;
+  };
+}
+
+function parseSVG(svg: string) {
+  const content = svg.match(/<svg(*.)<\/svg>/ims)[1];
+  const [, attrs, innerSVG] = content.match(/(.*?)>(.*)/ims);
+  const attributes = [
+    ...matchAll(attrs)(/([a-z0-9]+)(=['"](.*?)['"])?[\s>]/gims),
+  ].map(([, key, , value]) => ({ [key]: value }));
+  return { attributes, innerSVG };
+}
+
+function kebabToCamel(obj) {
+  const camelObj = {};
+  Object.keys(obj).forEach(key => {
+    camelObj[key.replace(/-./g, x => x.toUpperCase()[1])] = obj[key];
+  });
+  return camelObj;
+}

--- a/src/SvgXml.web.tsx
+++ b/src/SvgXml.web.tsx
@@ -12,7 +12,7 @@ type SvgXmlProps = XmlProps &
     title?: string;
   };
 const SvgXml = React.forwardRef<HTMLOrSVGElement, SvgXmlProps>(
-  ({ xml, ...props }) => {
+  ({ xml, ...props }, fowardRef) => {
     const { attributes, innerSVG } = parseSVG(xml);
     const camelAttributes = kebabToCamel(attributes);
 
@@ -45,9 +45,14 @@ const SvgXml = React.forwardRef<HTMLOrSVGElement, SvgXmlProps>(
 
     const finalProps = { ...camelAttributes, ...overrideProps };
     const Svg = unstable_createElement('svg', { ref: svgRef, ...finalProps });
+
+    const containerDefaultStyles = {
+      width,
+      height,
+    };
     return (
-      <View {...containerProps}>
-        <Svg />
+      <View ref={fowardRef} {...containerProps} style={containerDefaultStyles}>
+        {Svg}
       </View>
     );
   },
@@ -70,7 +75,7 @@ function matchAll(str) {
 }
 
 function parseSVG(svg: string) {
-  const content = svg.match(/<svg(*.)<\/svg>/ims)[1];
+  const content = svg.match(/<svg(.*)<\/svg>/ims)[1];
   const [, attrs, innerSVG] = content.match(/(.*?)>(.*)/ims);
   const attributes = [
     ...matchAll(attrs)(/([a-z0-9]+)(=['"](.*?)['"])?[\s>]/gims),

--- a/src/SvgXml.web.tsx
+++ b/src/SvgXml.web.tsx
@@ -132,6 +132,7 @@ const SvgXml = React.forwardRef<HTMLOrSVGElement, SvgXmlProps>(
       fill,
       fillOpacity,
       fillRule,
+      transform,
       stroke,
       strokeWidth,
       strokeOpacity,
@@ -140,7 +141,6 @@ const SvgXml = React.forwardRef<HTMLOrSVGElement, SvgXmlProps>(
       strokeLinecap,
       strokeLinejoin,
       strokeMiterlimit,
-      transform,
       clipRule,
       clipPath,
       vectorEffect,
@@ -150,14 +150,47 @@ const SvgXml = React.forwardRef<HTMLOrSVGElement, SvgXmlProps>(
       markerMid,
       markerEnd,
       mask,
+      originX,
+      originY,
+      translate,
+      scale,
+      rotation,
+      skewX,
+      skewY,
       // props that should be applyed to the View container
       ...containerProps
     } = props;
+
+    const transformArr = [];
+
+    if (originX != null || originY != null) {
+      transformArr.push(`translate(${originX || 0}, ${originY || 0})`);
+    }
+    if (translate != null) {
+      transformArr.push(`translate(${translate})`);
+    }
+    if (scale != null) {
+      transformArr.push(`scale(${scale})`);
+    }
+    // rotation maps to rotate, not to collide with the text rotate attribute (which acts per glyph rather than block)
+    if (rotation != null) {
+      transformArr.push(`rotate(${rotation})`);
+    }
+    if (skewX != null) {
+      transformArr.push(`skewX(${skewX})`);
+    }
+    if (skewY != null) {
+      transformArr.push(`skewY(${skewY})`);
+    }
+    if (originX != null || originY != null) {
+      transformArr.push(`translate(${-originX || 0}, ${-originY || 0})`);
+    }
 
     // these props should override the xml props
     const overrideProps = {
       height: '100%',
       width: '100%',
+      transform: transformArr.length ? transformArr.join(' ') : transform,
       viewBox,
       preserveAspectRatio,
       color,
@@ -174,7 +207,6 @@ const SvgXml = React.forwardRef<HTMLOrSVGElement, SvgXmlProps>(
       strokeLinecap,
       strokeLinejoin,
       strokeMiterlimit,
-      transform,
       clipRule,
       clipPath,
       vectorEffect,

--- a/src/SvgXml.web.tsx
+++ b/src/SvgXml.web.tsx
@@ -1,7 +1,23 @@
 import React from 'react';
-import { ViewProps } from 'react-native';
+import {
+  ViewProps,
+  GestureResponderHandlers,
+  GestureResponderEvent,
+} from 'react-native';
 import { View, unstable_createElement } from 'react-native-web';
-import { XmlProps } from './xml';
+// rgba values inside range 0 to 1 inclusive
+// rgbaArray = [r, g, b, a]
+export type rgbaArray = ReadonlyArray<number>;
+
+// argb values inside range 0x00 to 0xff inclusive
+// int32ARGBColor = 0xaarrggbb
+export type int32ARGBColor = number;
+type NumberProp = string | number;
+type Color = int32ARGBColor | rgbaArray | string;
+type FillRule = 'evenodd' | 'nonzero';
+type Linecap = 'butt' | 'square' | 'round';
+type Linejoin = 'miter' | 'bevel' | 'round';
+type NumberArray = NumberProp[] | NumberProp;
 /*
 
   ColumnMajorTransformMatrix
@@ -17,7 +33,7 @@ import { XmlProps } from './xml';
   ╚═      ═╝
 
 */
-export type ColumnMajorTransformMatrix = [
+type ColumnMajorTransformMatrix = [
   number,
   number,
   number,
@@ -25,19 +41,25 @@ export type ColumnMajorTransformMatrix = [
   number,
   number,
 ];
-// rgba values inside range 0 to 1 inclusive
-// rgbaArray = [r, g, b, a]
-export type rgbaArray = ReadonlyArray<number>;
-
-// argb values inside range 0x00 to 0xff inclusive
-// int32ARGBColor = 0xaarrggbb
-export type int32ARGBColor = number;
-type NumberProp = string | number;
-type FillRule = 'evenodd' | 'nonzero';
-type Linecap = 'butt' | 'square' | 'round';
-type Linejoin = 'miter' | 'bevel' | 'round';
-type Color = int32ARGBColor | rgbaArray | string;
-type NumberArray = NumberProp[] | NumberProp;
+interface ClipProps {
+  clipRule?: FillRule;
+  clipPath?: string;
+}
+interface FillProps {
+  fill?: Color;
+  fillOpacity?: NumberProp;
+  fillRule?: FillRule;
+}
+interface StrokeProps {
+  stroke?: Color;
+  strokeWidth?: NumberProp;
+  strokeOpacity?: NumberProp;
+  strokeDasharray?: ReadonlyArray<NumberProp> | NumberProp;
+  strokeDashoffset?: NumberProp;
+  strokeLinecap?: Linecap;
+  strokeLinejoin?: Linejoin;
+  strokeMiterlimit?: NumberProp;
+}
 interface TransformObject {
   translate?: NumberArray;
   translateX?: NumberProp;
@@ -55,60 +77,74 @@ interface TransformObject {
   x?: NumberArray;
   y?: NumberArray;
 }
-type SvgXmlProps = XmlProps &
-  ViewProps & {
-    height: NumberProp;
-    width: NumberProp;
-    viewBox?: string;
-    preserveAspectRatio?: string;
-    color?: Color;
-    title?: string;
-    opacity?: NumberProp;
-    fill?: Color;
-    fillOpacity?: number;
-    fillRule?: FillRule;
-    stroke?: Color;
-    strokeWidth?: NumberProp;
-    strokeOpacity?: NumberProp;
-    strokeDasharray?: ReadonlyArray<NumberProp> | NumberProp;
-    strokeDashoffset?: NumberProp;
-    strokeLinecap?: Linecap;
-    strokeLinejoin?: Linejoin;
-    strokeMiterlimit?: NumberProp;
-    clipRule?: FillRule;
-    clipPath?: string;
-    transform?: ColumnMajorTransformMatrix | string | TransformObject;
-    translate?: NumberArray;
-    translateX?: NumberProp;
-    translateY?: NumberProp;
-    origin?: NumberArray;
-    originX?: NumberProp;
-    originY?: NumberProp;
-    scale?: NumberArray;
-    scaleX?: NumberProp;
-    scaleY?: NumberProp;
-    skew?: NumberArray;
-    skewX?: NumberProp;
-    skewY?: NumberProp;
-    rotation?: NumberProp;
-    x?: NumberArray;
-    y?: NumberArray;
-    vectorEffect?:
-      | 'none'
-      | 'non-scaling-stroke'
-      | 'nonScalingStroke'
-      | 'default'
-      | 'inherit'
-      | 'uri';
-    pointerEvents?: 'box-none' | 'none' | 'box-only' | 'auto';
-    id?: string;
-    marker?: string;
-    markerStart?: string;
-    markerMid?: string;
-    markerEnd?: string;
-    mask?: string;
-  };
-const SvgXml = React.forwardRef<HTMLOrSVGElement, SvgXmlProps>(
+interface TransformProps extends TransformObject {
+  transform?: ColumnMajorTransformMatrix | string | TransformObject;
+}
+interface ResponderProps extends GestureResponderHandlers {
+  pointerEvents?: 'box-none' | 'none' | 'box-only' | 'auto';
+}
+interface VectorEffectProps {
+  vectorEffect?:
+    | 'none'
+    | 'non-scaling-stroke'
+    | 'nonScalingStroke'
+    | 'default'
+    | 'inherit'
+    | 'uri';
+}
+
+interface TouchableProps {
+  disabled?: boolean;
+  onPress?: (event: GestureResponderEvent) => void;
+  onPressIn?: (event: GestureResponderEvent) => void;
+  onPressOut?: (event: GestureResponderEvent) => void;
+  onLongPress?: (event: GestureResponderEvent) => void;
+  delayPressIn?: number;
+  delayPressOut?: number;
+  delayLongPress?: number;
+}
+interface DefinitionProps {
+  id?: string;
+}
+
+interface CommonMarkerProps {
+  marker?: string;
+  markerStart?: string;
+  markerMid?: string;
+  markerEnd?: string;
+}
+
+interface CommonMaskProps {
+  mask?: string;
+}
+
+interface CommonPathProps
+  extends FillProps,
+    StrokeProps,
+    ClipProps,
+    TransformProps,
+    VectorEffectProps,
+    ResponderProps,
+    TouchableProps,
+    DefinitionProps,
+    CommonMarkerProps,
+    CommonMaskProps {}
+interface GProps extends CommonPathProps {
+  opacity?: NumberProp;
+}
+interface SvgProps extends GProps, ViewProps {
+  width?: NumberProp;
+  height?: NumberProp;
+  viewBox?: string;
+  preserveAspectRatio?: string;
+  color?: Color;
+  title?: string;
+}
+interface XmlProps extends SvgProps {
+  xml: string | null;
+  override?: SvgProps;
+}
+const SvgXml = React.forwardRef<HTMLOrSVGElement, XmlProps>(
   ({ xml, ...props }, fowardRef) => {
     const { attributes, innerSVG } = parseSVG(xml);
     const camelAttributes = kebabToCamel(attributes);

--- a/src/SvgXml.web.tsx
+++ b/src/SvgXml.web.tsx
@@ -2,6 +2,29 @@ import React from 'react';
 import { ViewProps } from 'react-native';
 import { View, unstable_createElement } from 'react-native-web';
 import { XmlProps } from './xml';
+/*
+
+  ColumnMajorTransformMatrix
+
+  [a, b, c, d, tx, ty]
+
+  This matrix can be visualized as:
+
+  ╔═      ═╗
+  ║ a c tx ║
+  ║ b d ty ║
+  ║ 0 0 1  ║
+  ╚═      ═╝
+
+*/
+export type ColumnMajorTransformMatrix = [
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+];
 // rgba values inside range 0 to 1 inclusive
 // rgbaArray = [r, g, b, a]
 export type rgbaArray = ReadonlyArray<number>;
@@ -15,7 +38,23 @@ type Linecap = 'butt' | 'square' | 'round';
 type Linejoin = 'miter' | 'bevel' | 'round';
 type Color = int32ARGBColor | rgbaArray | string;
 type NumberArray = NumberProp[] | NumberProp;
-
+interface TransformObject {
+  translate?: NumberArray;
+  translateX?: NumberProp;
+  translateY?: NumberProp;
+  origin?: NumberArray;
+  originX?: NumberProp;
+  originY?: NumberProp;
+  scale?: NumberArray;
+  scaleX?: NumberProp;
+  scaleY?: NumberProp;
+  skew?: NumberArray;
+  skewX?: NumberProp;
+  skewY?: NumberProp;
+  rotation?: NumberProp;
+  x?: NumberArray;
+  y?: NumberArray;
+}
 type SvgXmlProps = XmlProps &
   ViewProps & {
     height: NumberProp;
@@ -38,6 +77,7 @@ type SvgXmlProps = XmlProps &
     strokeMiterlimit?: NumberProp;
     clipRule?: FillRule;
     clipPath?: string;
+    transform?: ColumnMajorTransformMatrix | string | TransformObject;
     translate?: NumberArray;
     translateX?: NumberProp;
     translateY?: NumberProp;
@@ -100,27 +140,12 @@ const SvgXml = React.forwardRef<HTMLOrSVGElement, SvgXmlProps>(
       strokeLinecap,
       strokeLinejoin,
       strokeMiterlimit,
+      transform,
       clipRule,
       clipPath,
-      translate,
-      translateX,
-      translateY,
-      origin,
-      originX,
-      originY,
-      scale,
-      scaleX,
-      scaleY,
-      skew,
-      skewX,
-      skewY,
-      rotation,
-      x,
-      y,
       vectorEffect,
       pointerEvents,
       id,
-      marker,
       markerStart,
       markerMid,
       markerEnd,
@@ -149,27 +174,12 @@ const SvgXml = React.forwardRef<HTMLOrSVGElement, SvgXmlProps>(
       strokeLinecap,
       strokeLinejoin,
       strokeMiterlimit,
+      transform,
       clipRule,
       clipPath,
-      translate,
-      translateX,
-      translateY,
-      origin,
-      originX,
-      originY,
-      scale,
-      scaleX,
-      scaleY,
-      skew,
-      skewX,
-      skewY,
-      rotation,
-      x,
-      y,
       vectorEffect,
       pointerEvents,
       id,
-      marker,
       markerStart,
       markerMid,
       markerEnd,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
#1279
#1236

* What is the feature? (if applicable)
This PR contains the implementation of SvgXml for web. This web implementation has exactly the same usage as the native implementation. 
* How did you implement the solution?
The web implementation relies on [unstable_createElement](https://github.com/necolas/react-native-web/blob/master/packages/react-native-web/src/exports/createElement/index.js)  and [View](https://github.com/necolas/react-native-web/blob/master/packages/react-native-web/src/exports/View/index.js) from [react-native-web](https://github.com/necolas/react-native-web). So, basically I used `unstable_createElement` to create an `<svg>` element with the props that comes from the XML string and set the `innerHTML` from the `<svg>` to be the XML content.
In order to accept react-native props (the same as SvgXml native implementation), I used the `<View>` to wrap the `<svg>` and simulate the same behavior.
* What areas of the library does it impact?
None. It just brings a new supported component for web.
## Test Plan

You can check a working demo here: https://codesandbox.io/s/keen-platform-z40rg

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Web |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on browser
