### PR TITLE
Update RNSVGRenderable.m

### DIFF
--- a/ios/RNSVGRenderable.m
+++ b/ios/RNSVGRenderable.m
@@ -370,9 +370,11 @@ UInt32 saturate(CGFloat value) {
     self.ctm = svgToClientTransform;
     self.clientRect = clientRect;
     self.screenCTM = current;
-
+    
     if (_vectorEffect == kRNSVGVectorEffectNonScalingStroke) {
-        path = CGPathCreateCopyByTransformingPath(path, &svgToClientTransform);
+        //Path was reassigned to new, copied object; need to call release somewhere
+        //but this function has multiple return points so I pick CFAutoRelease.
+        path = CFAutoRelease(CGPathCreateCopyByTransformingPath(path, &svgToClientTransform));
         CGContextConcatCTM(context, CGAffineTransformInvert(svgToClientTransform));
     }
 


### PR DESCRIPTION
Fixed memory leak when calling CGPathCreateCopyByTransformingPath (it's never released)

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
https://github.com/react-native-community/react-native-svg/issues/1436

* What is the feature? (if applicable)
Fixed memory leak

* How did you implement the solution?
Added CFAutoRelease to the temporary path object

* What areas of the library does it impact?
Rendering vectorEffect="nonScalingStroke"

## Test Plan
Render this
````
<Path d={someData} strokeWidth={2} stroke="black" strokeLinecap="round" vectorEffect="nonScalingStroke"  />
````

### What's required for testing (prerequisites)?
React native
> Show memory debugger when running the code as above

## Compatibility
This only affects iOS

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
