### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/RNSVG.podspec
+++ b/RNSVG.podspec
@@ -13,5 +13,5 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/react-native-community/react-native-svg.git', :tag => "v#{s.version}" }
   s.source_files     = 'ios/**/*.{h,m}'
   s.requires_arc     = true
-  s.dependency         'React'
+  s.dependency         'React-Core'
 end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Latest Xcode 12 fails to build while without a module to depend on `React-Core` directly hence this change is necessary for native modules on iOS. This change requires to React Native 0.60.2 or newer. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116

## Test Plan

Use this branch to install with an app running on Xcode 12 (and 11). This is not a breaking change.


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
